### PR TITLE
feat: monochrome official social icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "framer-motion": "^10.16.16",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-icons": "^4.11.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -3311,6 +3312,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "framer-motion": "^10.16.16",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-icons": "^4.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SocialLinks } from './SocialLinks';
 
 export function Footer() {
   return (
@@ -14,14 +15,17 @@ export function Footer() {
             contact@krglobalsolutionsltd.com
           </a>
         </p>
-        <a
-          href="/legal"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
-        >
-          Mentions légales
-        </a>
+        <div className="flex items-center gap-4">
+          <SocialLinks />
+          <a
+            href="/legal"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
+          >
+            Mentions légales
+          </a>
+        </div>
       </div>
     </footer>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,7 +49,7 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
 
             {/* Liens sociaux */}
             <div className="hidden lg:block">
-              <SocialLinks t={t} />
+              <SocialLinks />
             </div>
 
             {/* Sélecteur de langue */}

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -1,69 +1,65 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import { FaTiktok, FaInstagram, FaLinkedin, FaGithub } from 'react-icons/fa';
+import { SiFiverr } from 'react-icons/si';
 
 interface SocialLinksProps {
-  t: any;
   className?: string;
   showLabels?: boolean;
 }
 
 const socialLinks = [
-  { 
-    name: 'tiktok', 
-    url: 'https://tiktok.com/@krglobal', 
-    icon: '📱',
-    color: 'hover:text-pink-600'
+  {
+    name: 'TikTok',
+    url: 'https://tiktok.com/@krglobal',
+    icon: FaTiktok
   },
-  { 
-    name: 'instagram', 
-    url: 'https://instagram.com/krglobal', 
-    icon: '📷',
-    color: 'hover:text-purple-600'
+  {
+    name: 'Instagram',
+    url: 'https://instagram.com/krglobal',
+    icon: FaInstagram
   },
-  { 
-    name: 'fiverr', 
-    url: 'https://fiverr.com/karimhammouche', 
-    icon: '💼',
-    color: 'hover:text-green-600'
+  {
+    name: 'Fiverr',
+    url: 'https://fiverr.com/karimhammouche',
+    icon: SiFiverr
   },
-  { 
-    name: 'linkedin', 
-    url: 'https://linkedin.com/company/krglobal', 
-    icon: '💼',
-    color: 'hover:text-blue-600'
+  {
+    name: 'LinkedIn',
+    url: 'https://linkedin.com/company/krglobal',
+    icon: FaLinkedin
   },
-  { 
-    name: 'github', 
-    url: 'https://github.com/krglobal', 
-    icon: '⚡',
-    color: 'hover:text-gray-600'
-  },
+  {
+    name: 'GitHub',
+    url: 'https://github.com/krglobal',
+    icon: FaGithub
+  }
 ];
 
-export function SocialLinks({ t, className = '', showLabels = false }: SocialLinksProps) {
+export function SocialLinks({ className = '', showLabels = false }: SocialLinksProps) {
   return (
     <div className={`flex items-center gap-4 ${className}`}>
-      {socialLinks.map((link, index) => (
-        <motion.a
-          key={link.name}
-          href={link.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={`flex items-center gap-2 text-sm font-medium transition-colors duration-300 ${link.color}`}
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.3, delay: index * 0.1 }}
-        >
-          <span className="text-lg">{link.icon}</span>
-          {showLabels && (
-            <span className="hidden sm:inline">
-              {t.footer.social[link.name as keyof typeof t.footer.social]}
-            </span>
-          )}
-        </motion.a>
-      ))}
+      {socialLinks.map((link, index) => {
+        const Icon = link.icon;
+        return (
+          <motion.a
+            key={link.name}
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={link.name}
+            className="flex items-center gap-2 text-sm font-medium text-black dark:text-white hover:opacity-75 transition"
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: index * 0.1 }}
+          >
+            <Icon className="w-6 h-6" />
+            {showLabels && <span className="hidden sm:inline">{link.name}</span>}
+          </motion.a>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace emoji placeholders with official monochrome icons from `react-icons`
- wire updated `SocialLinks` component into header and footer
- add `react-icons` dependency for standardized branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689776e266b48331b1e1da4164d98466