### PR TITLE
feat: add KR brand component

### DIFF
--- a/src/components/BrandKR.tsx
+++ b/src/components/BrandKR.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+export default function BrandKR({
+  karim = "https://www.karimhammouche.com/",
+  raphael = "https://rthportofolio.com",
+}: { karim?: string; raphael?: string }) {
+  const base = "inline-flex items-center gap-1 font-extrabold text-xl md:text-2xl tracking-tight";
+  const letter =
+    "cursor-pointer select-none transition hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black rounded";
+
+  const scrollTop = () => window.scrollTo({ top: 0, behavior: "smooth" });
+
+  return (
+    <div className={base} aria-label="KR" onClick={scrollTop}>
+      <span
+        className={letter}
+        onClick={(e) => { e.stopPropagation(); window.location.href = karim; }}
+        title="Portfolio Karim"
+      >
+        K
+      </span>
+      <span
+        className={letter}
+        onClick={(e) => { e.stopPropagation(); window.location.href = raphael; }}
+        title="Portfolio Raphaël"
+      >
+        R
+      </span>
+    </div>
+  );
+}
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { LanguageSelector } from './LanguageSelector';
 import { SocialLinks } from './SocialLinks';
 import { Language } from '../data/translations';
+import BrandKR from '@/components/BrandKR';
 
 interface HeaderProps {
   currentLanguage: Language;
@@ -16,9 +17,7 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex-shrink-0">
-            <h1 className="text-xl font-medium tracking-wide text-black">
-              KR Global LTD
-            </h1>
+            <BrandKR />
           </div>
           
           <div className="flex items-center gap-6">

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add reusable BrandKR component that links to Karim and Raphaël portfolios
- replace header title with BrandKR
- configure path alias for simplified imports

## Testing
- `npm run lint` (fails: Unexpected any in multiple components)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689823ff48e0833195c0aa3d9ff5ed87