### PR TITLE
feat: add multilingual infinite headline

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>KR Global LTD — Connecter l'innovation au monde</title>
-    <meta name="description" content="Solutions digitales, e-commerce et technologies pour demain. KR Global LTD connecte l'innovation au monde avec des services sur mesure." />
+    <title>KR Global Solutions — Connecter l'innovation au monde</title>
+    <meta name="description" content="Solutions digitales, e-commerce et technologies pour demain. KR Global Solutions connecte l'innovation au monde avec des services sur mesure." />
     <meta name="keywords" content="digital solutions, e-commerce, technology, innovation, KR Global" />
     
     <!-- Open Graph -->
-    <meta property="og:title" content="KR Global LTD — Connecter l'innovation au monde" />
+    <meta property="og:title" content="KR Global Solutions — Connecter l'innovation au monde" />
     <meta property="og:description" content="Solutions digitales, e-commerce et technologies pour demain." />
     <meta property="og:type" content="website" />
     

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
       />
       
       <main>
-        <HeroSection t={t} isRTL={isRTL} />
+        <HeroSection t={t} />
         <AboutSection t={t} isRTL={isRTL} />
       </main>
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { ExternalLink } from 'lucide-react';
+import InfiniteHeadline from '@/components/InfiniteHeadline';
 
 interface HeroSectionProps {
   t: any;
-  isRTL: boolean;
 }
 
 const orbitalButtons = [
@@ -29,7 +29,7 @@ const portfolioButtons = [
     className: 'button type1'
   },
 ];
-export function HeroSection({ t, isRTL }: HeroSectionProps) {
+export function HeroSection({ t }: HeroSectionProps) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const handleCardClick = (buttonKey: string, url: string) => {
@@ -49,10 +49,8 @@ export function HeroSection({ t, isRTL }: HeroSectionProps) {
           transition={{ duration: 0.8 }}
           className="mb-16"
         >
-          <h1 className="text-4xl md:text-6xl font-bold text-black mb-6 leading-tight">
-            {t.hero.title}
-          </h1>
-          <p className="text-lg md:text-xl text-neutral-600 max-w-3xl mx-auto">
+          <InfiniteHeadline />
+          <p className="mt-6 text-lg md:text-xl text-neutral-600 max-w-3xl mx-auto">
             {t.hero.subtitle}
           </p>
         </motion.div>

--- a/src/components/InfiniteHeadline.tsx
+++ b/src/components/InfiniteHeadline.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+
+export default function InfiniteHeadline({
+  speed = 35,         // px/s
+  switchEvery = 5000, // ms
+}: { speed?: number; switchEvery?: number }) {
+  const messages = useMemo(
+    () => [
+      { lang: "fr", dir: "ltr", text: "KR Global Solutions — Connecter l'innovation au monde" },
+      { lang: "en", dir: "ltr", text: "KR Global Solutions — Connecting innovation to the world" },
+      { lang: "ar", dir: "rtl", text: "KR Global Solutions — نربط الابتكار بالعالم" },
+      { lang: "ja", dir: "ltr", text: "KR Global Solutions — 世界へイノベーションをつなぐ" },
+    ],
+    []
+  );
+
+  const [idx, setIdx] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setIdx((i) => (i + 1) % messages.length), switchEvery);
+    return () => clearInterval(id);
+  }, [switchEvery, messages.length]);
+
+  const current = messages[idx];
+
+  return (
+    <div className="w-full overflow-hidden border-y border-neutral-200 dark:border-neutral-800 select-none">
+      <div
+        key={current.lang}
+        lang={current.lang}
+        dir={current.dir as "ltr" | "rtl"}
+        className="relative whitespace-nowrap py-3"
+        style={{
+          "--marquee-duration": `${Math.max(10, Math.floor(1200 / speed))}s`,
+        } as CSSProperties}
+      >
+        <div className="marquee inline-flex">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <span key={i} className="mx-6 text-2xl md:text-4xl font-extrabold tracking-tight">
+              {current.text}
+            </span>
+          ))}
+        </div>
+      </div>
+      <style jsx>{`
+        .marquee { animation: marquee linear var(--marquee-duration) infinite; will-change: transform; }
+        @keyframes marquee {
+          from { transform: translateX(0); }
+          to   { transform: translateX(-50%); }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add multilingual InfiniteHeadline marquee component
- replace hero title with marquee banner
- update home metadata title and description

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in existing components)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689824e1bdf483318940061d7c1e3f36