### PR TITLE
feat: add WhatsApp business button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Header } from './components/Header';
 import { HeroSection } from './components/HeroSection';
 import { AboutSection } from './components/AboutSection';
 import { Footer } from './components/Footer';
+import WhatsAppButton from '@/components/WhatsAppButton';
 
 function App() {
   const { currentLanguage, changeLanguage, t, isRTL } = useLanguage();
@@ -28,6 +29,7 @@ function App() {
       </main>
 
       <Footer />
+      <WhatsAppButton />
     </motion.div>
   );
 }

--- a/src/components/WhatsAppButton.tsx
+++ b/src/components/WhatsAppButton.tsx
@@ -1,0 +1,15 @@
+"use client";
+export default function WhatsAppButton() {
+  return (
+    <a
+      href="https://wa.me/message/LWWQOYH6PZN5M1"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="WhatsApp Business"
+      className="fixed left-4 bottom-4 z-50 rounded-full shadow-lg px-4 py-3 bg-black text-white hover:opacity-90 transition"
+    >
+      WhatsApp
+    </a>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add floating WhatsApp button component
- include WhatsApp button in main app layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689827e041c08331b2996fe818ee4018