### PR TITLE
feat: add dark zone monochrome mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "check:mobile": "npm run lint && npm run build && node tests/no-overflow.mjs"
+    "check:mobile": "npm run lint && npm run build && node tests/no-overflow.mjs",
+    "dz:rollback": "git restore -SW .",
+    "dz:verify": "node scripts/dz-verify.mjs"
   },
   "dependencies": {
     "framer-motion": "^10.16.16",

--- a/scripts/dz-verify.mjs
+++ b/scripts/dz-verify.mjs
@@ -1,0 +1,32 @@
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+
+// SAFE-GUARD: ensures Dark Zone additions stay monochrome
+const allowed = new Set(['#000000', '#ffffff', '#111', '#161616', '#1f1f1f', '#e5e5e5', '#f5f5f5', '#2a2a2a']);
+
+const files = execSync('git diff --name-only --diff-filter=ACM HEAD').toString().trim().split('\n').filter(Boolean);
+let ok = true;
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  const matches = text.match(/#([0-9a-fA-F]{3,6})/g) || [];
+  for (const m of matches) {
+    const hex = m.length === 4 ? `#${m[1]}${m[1]}${m[2]}${m[2]}${m[3]}${m[3]}` : m.toLowerCase();
+    if (!allowed.has(hex)) {
+      console.error(`Disallowed color ${m} in ${file}`);
+      ok = false;
+    }
+  }
+}
+
+const css = readFileSync('src/index.css', 'utf8');
+if (!css.includes('.dark-zone')) {
+  console.error('Missing .dark-zone utilities in src/index.css');
+  ok = false;
+}
+
+if (ok) {
+  console.log('Dark Zone verification passed');
+} else {
+  process.exit(1);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,27 @@ import { HeroSection } from './components/HeroSection';
 import { AboutSection } from './components/AboutSection';
 import { Footer } from './components/Footer';
 import WhatsAppButton from '@/components/WhatsAppButton';
+import { ENABLE_DZ_PARTICLES } from './featureFlags';
+
+const DarkZoneParticles = React.lazy(() => import('./components/DarkZoneParticles'));
 
 function App() {
   const { currentLanguage, changeLanguage, t, isRTL } = useLanguage();
+  const [showParticles, setShowParticles] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!ENABLE_DZ_PARTICLES) return;
+    const body = document.body;
+    const update = () => setShowParticles(body.classList.contains('dark-zone'));
+    const observer = new MutationObserver(update);
+    observer.observe(body, { attributes: true, attributeFilter: ['class'] });
+    update();
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <motion.div
-      className="min-h-screen bg-white"
+      className="min-h-screen bg-white dz-bg dz-fg"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
@@ -30,6 +44,11 @@ function App() {
 
       <Footer />
       <WhatsAppButton />
+      {ENABLE_DZ_PARTICLES && showParticles && (
+        <React.Suspense fallback={null}>
+          <DarkZoneParticles />
+        </React.Suspense>
+      )}
     </motion.div>
   );
 }

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -9,7 +9,7 @@ interface AboutSectionProps {
 
 export function AboutSection({ t, isRTL }: AboutSectionProps) {
   return (
-    <section id="about" className="py-10 md:py-20 bg-white">
+    <section id="about" className="py-10 md:py-20 bg-white dz-bg dz-fg">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-12 items-center">
           <motion.div
@@ -18,7 +18,7 @@ export function AboutSection({ t, isRTL }: AboutSectionProps) {
             viewport={{ once: true }}
             transition={{ duration: 0.8 }}
           >
-            <h2 className="fs-xl md:text-4xl font-bold text-black mb-6 break-words">
+            <h2 className="fs-xl md:text-4xl font-bold text-black mb-6 break-words dz-fg">
               {t.about.title}
             </h2>
           </motion.div>
@@ -29,7 +29,7 @@ export function AboutSection({ t, isRTL }: AboutSectionProps) {
             viewport={{ once: true }}
             transition={{ duration: 0.8, delay: 0.2 }}
           >
-            <p className="fs-base text-neutral-600 leading-relaxed break-words">
+            <p className="fs-base text-neutral-600 leading-relaxed break-words dz-fg">
               {t.about.content}
             </p>
           </motion.div>

--- a/src/components/DarkZoneParticles.tsx
+++ b/src/components/DarkZoneParticles.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+/**
+ * Sparse particle backdrop for Dark Zone mode.
+ * SAFE-GUARD: rendering is gated by feature flag and body class.
+ */
+export default function DarkZoneParticles() {
+  const canvasRef = React.useRef<HTMLCanvasElement>(null);
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    if (!canvas || !ctx) return;
+
+    const colors = ['#fff', '#e5e5e5', '#f5f5f5'];
+    const particles = Array.from({ length: 40 }, () => ({
+      x: Math.random() * window.innerWidth,
+      y: Math.random() * window.innerHeight,
+      r: Math.random() * 1.5 + 0.5,
+      v: Math.random() * 0.3 + 0.1,
+      color: colors[Math.floor(Math.random() * colors.length)],
+    }));
+
+    let raf = 0;
+    let last = 0;
+    const fps = 30;
+
+    const render = (time: number) => {
+      if (document.hidden) {
+        raf = requestAnimationFrame(render);
+        return;
+      }
+      if (time - last < 1000 / fps) {
+        raf = requestAnimationFrame(render);
+        return;
+      }
+      last = time;
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      particles.forEach((p) => {
+        p.y += p.v;
+        if (p.y > canvas.height) {
+          p.y = 0;
+          p.x = Math.random() * canvas.width;
+        }
+        ctx.fillStyle = p.color;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fill();
+      });
+      raf = requestAnimationFrame(render);
+    };
+
+    raf = requestAnimationFrame(render);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="fixed inset-0 pointer-events-none"
+      style={{ zIndex: -1 }}
+    />
+  );
+}

--- a/src/components/DarkZoneToggle.tsx
+++ b/src/components/DarkZoneToggle.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+
+interface DarkZoneToggleProps {
+  label?: string;
+}
+
+/**
+ * Toggle for the experimental Dark Zone mode.
+ * SAFE-GUARD: independent component; avoids altering existing theming logic.
+ */
+export function DarkZoneToggle({ label = 'Dark Zone' }: DarkZoneToggleProps) {
+  const [enabled, setEnabled] = React.useState(false);
+  const reduceMotion = useReducedMotion();
+
+  // Initialize from localStorage
+  React.useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('dark-zone') : null;
+    const isOn = stored === 'on';
+    setEnabled(isOn);
+    if (isOn) {
+      document.body.classList.add('dark-zone');
+    }
+  }, []);
+
+  // Apply class to body and persist
+  React.useEffect(() => {
+    if (enabled) {
+      document.body.classList.add('dark-zone');
+      localStorage.setItem('dark-zone', 'on');
+    } else {
+      document.body.classList.remove('dark-zone');
+      localStorage.setItem('dark-zone', 'off');
+    }
+  }, [enabled]);
+
+  const toggle = () => setEnabled((v) => !v);
+
+  return (
+    <motion.button
+      type="button"
+      aria-pressed={enabled}
+      aria-label={label}
+      onClick={toggle}
+      className="ml-2 rounded-full dz-card dz-fg dz-glow focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+      style={{
+        width: 44,
+        height: 44,
+        backgroundColor: '#fff',
+        color: '#000',
+        border: '1px solid #e5e5e5',
+      }}
+      whileTap={reduceMotion ? undefined : { scale: 0.95 }}
+      transition={{ duration: 0.2 }}
+    >
+      <motion.svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        animate={{ rotate: enabled ? 45 : 0 }}
+        transition={{ duration: reduceMotion ? 0 : 0.2 }}
+      >
+        {/* SAFE-GUARD: minimalistic circle icon to match N&B requirement */}
+        <circle cx="12" cy="12" r="9" />
+      </motion.svg>
+    </motion.button>
+  );
+}
+
+export default DarkZoneToggle;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { LanguageSelector } from './LanguageSelector';
 import SocialLinks from "@/components/SocialLinks";
 import { Language, Translation } from '../data/translations';
 import KRLogo from '@/components/KRLogo';
+import { DarkZoneToggle } from './DarkZoneToggle';
 
 interface HeaderProps {
   currentLanguage: Language;
@@ -12,7 +13,7 @@ interface HeaderProps {
 
 export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
   return (
-    <header className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-neutral-200">
+    <header className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-neutral-200 dz-card dz-border dz-fg">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
         <div className="flex items-center gap-3 min-w-0">
           <KRLogo t={t} />
@@ -21,6 +22,8 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
             onLanguageChange={onLanguageChange}
             t={t}
           />
+          {/* SAFE-GUARD: isolated toggle to avoid interfering with existing nav */}
+          <DarkZoneToggle label={t.nav.darkZone} />
         </div>
         <div className="flex items-center justify-end flex-1 overflow-hidden">
           <SocialLinks variant="header" size={20} className="justify-end" />

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -20,7 +20,7 @@ const radius = 120;
 
 export function HeroSection({ t }: HeroSectionProps) {
   return (
-    <section className="min-h-screen flex items-center justify-center py-10 sm:py-20 bg-gradient-to-br from-white to-neutral-50">
+    <section className="min-h-screen flex items-center justify-center py-10 sm:py-20 bg-gradient-to-br from-white to-neutral-50 dz-bg dz-fg">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
         {/* Title and Subtitle */}
         <motion.div

--- a/src/data/translations.ts
+++ b/src/data/translations.ts
@@ -3,6 +3,7 @@ export type Language = 'fr' | 'en';
 export interface Translation {
   nav: {
     language: string;
+    darkZone: string; // SAFE-GUARD: additive key for Dark Zone label
     menu: {
       open: string;
       close: string;
@@ -67,6 +68,7 @@ export const translations: Record<Language, Translation> = {
   fr: {
     nav: {
       language: 'Langue',
+      darkZone: 'Dark Zone',
       menu: { open: 'Ouvrir le menu', close: 'Fermer le menu' },
       social: {
         tiktok: 'TikTok',
@@ -126,6 +128,7 @@ export const translations: Record<Language, Translation> = {
   en: {
     nav: {
       language: 'Language',
+      darkZone: 'Dark Zone',
       menu: { open: 'Open menu', close: 'Close menu' },
       social: {
         tiktok: 'TikTok',

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -1,0 +1,2 @@
+// SAFE-GUARD: feature flags for experimental options
+export const ENABLE_DZ_PARTICLES = false;

--- a/src/index.css
+++ b/src/index.css
@@ -92,3 +92,38 @@ html[dir="rtl"] .space-x-2 > * + * {
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
+
+/* Dark Zone utility layer */
+body {
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.dark-zone {
+  --dz-bg: #000;
+  --dz-fg: #fff;
+  --dz-border: #2a2a2a;
+  --dz-muted: #111;
+}
+
+.dark-zone .dz-bg {
+  background: var(--dz-bg);
+}
+
+.dark-zone .dz-fg {
+  color: var(--dz-fg);
+}
+
+.dark-zone .dz-card {
+  background-color: var(--dz-muted);
+  border: 1px solid var(--dz-border);
+}
+
+.dark-zone .dz-border {
+  border-color: var(--dz-border);
+}
+
+.dark-zone .dz-glow:hover,
+.dark-zone .dz-glow:focus-visible {
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.25),
+    0 0 24px rgba(255, 255, 255, 0.12);
+}


### PR DESCRIPTION
## Summary
- add dark zone toggle storing preference and applying body class
- introduce monochrome utilities and optional particles component
- add guard scripts for rollback and color verification

## Testing
- `npm run lint`
- `npm run build`
- `node tests/no-overflow.mjs`
- `npm run dz:verify`


------
https://chatgpt.com/codex/tasks/task_b_689871e599848331bd2389ad1962f1f3