### PR TITLE
feat(hero): add URL-based HeroVideo component

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { ExternalLink } from 'lucide-react';
 import InfiniteHeadline from '@/components/InfiniteHeadline';
 import { Translation } from '../data/translations';
-import HeroVideo from '@/components/HeroVideo';
+import HeroVideoURL from '@/components/HeroVideoURL';
 
 interface HeroSectionProps {
   t: Translation;
@@ -36,7 +36,7 @@ export function HeroSection({ t }: HeroSectionProps) {
 
           {/* --- Video placed directly under the subtitle --- */}
           <div className="mt-6 md:mt-8">
-            <HeroVideo />
+            <HeroVideoURL />
           </div>
         </motion.div>
 

--- a/src/components/HeroVideoURL.tsx
+++ b/src/components/HeroVideoURL.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+const MOV_URL = "https://rseczxloemshthscxuoa.supabase.co/storage/v1/object/public/videologo/Cinematic_blackandwhite_space_202508092340_.mov";
+// Optionnel : si tu ajoutes plus tard des versions optimisées :
+const WEBM_URL: string | null = null; // ex: "/videos/hero.webm"
+const MP4_URL:  string | null = null; // ex: "/videos/hero.mp4"
+const POSTER_URL: string | undefined = undefined; // ex: "/videos/hero-poster.jpg"
+
+export default function HeroVideoURL() {
+  const ref = useRef<HTMLVideoElement | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [visible, setVisible] = useState(true); // visible par défaut
+
+  // IO: joue quand visible, pause sinon (simple et robuste)
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => setVisible(entries[0]?.isIntersecting ?? true),
+      { threshold: 0.01 }
+    );
+    io.observe(el);
+    return () => {
+      // SAFE-GUARD: prevent leaks by disconnecting observer on unmount
+      io.disconnect();
+    };
+  }, []);
+
+  // Autoplay iOS/desktop
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.muted = true; // SAFE-GUARD: requis pour autoplay iOS
+    if (visible) {
+      el.play().catch(() => {
+        // SAFE-GUARD: si l’autoplay est bloqué, on laisse l’utilisateur cliquer
+      });
+    } else {
+      el.pause();
+    }
+  }, [visible]);
+
+  return (
+    <div className="relative w-full aspect-video min-h-[260px] sm:min-h-[360px] overflow-hidden rounded-xl bg-black">
+      {!loaded && (
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-black"
+          style={POSTER_URL ? { backgroundImage: `url(${POSTER_URL})`, backgroundSize: "cover", backgroundPosition: "center" } : undefined}
+        />
+      )}
+      <video
+        ref={ref}
+        className="w-full h-full object-cover"
+        autoPlay
+        muted
+        loop
+        playsInline
+        preload="metadata"
+        poster={POSTER_URL}
+        onLoadedData={() => setLoaded(true)}
+      >
+        {/* Ordre conseillé si un jour tu ajoutes les formats optimisés */}
+        {WEBM_URL && <source src={WEBM_URL} type="video/webm" />}
+        {MP4_URL  && <source src={MP4_URL}  type="video/mp4" />}
+        {/* Fallback actuel : MOV public (type mp4 pour compat HLS/avc) */}
+        <source src={MOV_URL} type='video/mp4; codecs="h264"' />
+        Votre navigateur ne supporte pas la vidéo HTML5.
+      </video>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add standalone URL-based HeroVideoURL component with responsive B/W styling
- replace existing hero video usage with new component and safe-guards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6898742bf9c48331a619f44895df39d1