### PR TITLE
feat: refine dark mode toggle

### DIFF
--- a/src/components/DarkZoneToggle.tsx
+++ b/src/components/DarkZoneToggle.tsx
@@ -5,6 +5,42 @@ interface DarkZoneToggleProps {
   label?: string;
 }
 
+// Minimal sun icon – only black and white strokes
+const SunIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <circle cx="12" cy="12" r="5" />
+    <line x1="12" y1="1" x2="12" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="23" />
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+    <line x1="1" y1="12" x2="3" y2="12" />
+    <line x1="21" y1="12" x2="23" y2="12" />
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+  </svg>
+);
+
+// Minimal moon icon
+const MoonIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+);
+
 /**
  * Toggle for the experimental Dark Zone mode.
  * SAFE-GUARD: independent component; avoids altering existing theming logic.
@@ -36,36 +72,31 @@ export function DarkZoneToggle({ label = 'Dark Zone' }: DarkZoneToggleProps) {
 
   const toggle = () => setEnabled((v) => !v);
 
+  // Base + theme styles keep button tiny and monochrome
+  const baseClasses =
+    'ml-2 w-8 h-8 flex items-center justify-center rounded-full border transition-colors duration-200 focus:outline-none';
+  const themeClasses = enabled
+    ? 'bg-black text-white border-white hover:bg-neutral-900'
+    : 'bg-white text-black border-black hover:bg-neutral-100';
+
   return (
     <motion.button
       type="button"
       aria-pressed={enabled}
       aria-label={label}
       onClick={toggle}
-      className="ml-2 rounded-full dz-card dz-fg dz-glow focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-      style={{
-        width: 44,
-        height: 44,
-        backgroundColor: '#fff',
-        color: '#000',
-        border: '1px solid #e5e5e5',
-      }}
+      className={`${baseClasses} ${themeClasses} dz-glow`}
       whileTap={reduceMotion ? undefined : { scale: 0.95 }}
       transition={{ duration: 0.2 }}
     >
-      <motion.svg
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        animate={{ rotate: enabled ? 45 : 0 }}
-        transition={{ duration: reduceMotion ? 0 : 0.2 }}
+      <motion.span
+        key={enabled ? 'moon' : 'sun'}
+        animate={{ rotate: enabled ? 180 : 0 }}
+        transition={{ duration: reduceMotion ? 0 : 0.4 }}
+        className="block"
       >
-        {/* SAFE-GUARD: minimalistic circle icon to match N&B requirement */}
-        <circle cx="12" cy="12" r="9" />
-      </motion.svg>
+        {enabled ? <MoonIcon /> : <SunIcon />}
+      </motion.span>
     </motion.button>
   );
 }


### PR DESCRIPTION
## Summary
- make dark mode toggle small circular with sun & moon icons
- add smooth rotation animation and subtle hover

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689875d9fa0c8331b7fc82269df86abf