### PR TITLE
Fix WhatsApp button scroll behavior and move legal link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,25 +3,27 @@ import SocialLinks from '@/components/SocialLinks';
 
 export function Footer() {
   return (
-    <footer className="bg-black text-white py-6">
+    <footer id="site-footer" className="bg-black text-white py-6">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex flex-col sm:flex-row justify-between items-start gap-6 text-sm">
-        <p className="break-words">
-          Contact :{' '}
-          <a
-            href="mailto:contact@krglobalsolutionsltd.com"
-            className="underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
-            aria-label="Envoyer un e-mail à contact@krglobalsolutionsltd.com"
-          >
-            contact@krglobalsolutionsltd.com
-          </a>
-        </p>
-        <div className="flex flex-col sm:items-end gap-2 w-full sm:w-auto">
+        <div className="flex flex-col gap-2 w-full sm:w-auto">
+          <p className="break-words">
+            Contact :{' '}
+            <a
+              href="mailto:contact@krglobalsolutionsltd.com"
+              className="underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
+              aria-label="Envoyer un e-mail à contact@krglobalsolutionsltd.com"
+            >
+              contact@krglobalsolutionsltd.com
+            </a>
+          </p>
           <a
             href="/mentions-legales"
             className="underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
           >
             Mentions légales
           </a>
+        </div>
+        <div className="flex flex-col sm:items-end gap-2 w-full sm:w-auto">
           <SocialLinks variant="footer" size={22} className="justify-center sm:justify-end" />
         </div>
       </div>

--- a/src/components/WhatsAppButton.tsx
+++ b/src/components/WhatsAppButton.tsx
@@ -1,7 +1,45 @@
 "use client";
+import { useEffect, useRef } from 'react';
+
 export default function WhatsAppButton() {
+  const buttonRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    const updatePosition = () => {
+      const btn = buttonRef.current;
+      if (!btn) return;
+
+      if (window.innerWidth >= 1024) {
+        const footer = document.getElementById('site-footer');
+        const footerRect = footer?.getBoundingClientRect();
+        const baseBottom = 16; // Tailwind bottom-4
+        let bottom = baseBottom;
+
+        if (footerRect) {
+          const overlap = window.innerHeight - footerRect.top;
+          if (overlap > 0) {
+            bottom = overlap + baseBottom;
+          }
+        }
+
+        btn.style.bottom = `${bottom}px`;
+      } else {
+        btn.style.bottom = '';
+      }
+    };
+
+    updatePosition();
+    window.addEventListener('scroll', updatePosition);
+    window.addEventListener('resize', updatePosition);
+    return () => {
+      window.removeEventListener('scroll', updatePosition);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, []);
+
   return (
     <a
+      ref={buttonRef}
       href="https://wa.me/message/LWWQOYH6PZN5M1"
       target="_blank"
       rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- keep WhatsApp button following scroll on desktop and stop above footer
- move "Mentions légales" link under contact line and add footer id

## Testing
- `npm run lint`
- `npm run build`
- `npm run check:mobile`


------
https://chatgpt.com/codex/tasks/task_b_689887169f108331a6387213b8290239