### PR TITLE
fix(ui): keep existing WhatsApp button & link; add portal wrapper for fixed FAB

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { HeroSection } from './components/HeroSection';
 import { AboutSection } from './components/AboutSection';
 import { Footer } from './components/Footer';
 import WhatsAppButton from '@/components/WhatsAppButton';
+import FabPortal from "@/components/FabPortal";
 import { ENABLE_DZ_PARTICLES } from './featureFlags';
 
 const DarkZoneParticles = React.lazy(() => import('./components/DarkZoneParticles'));
@@ -43,7 +44,9 @@ function App() {
       </main>
 
       <Footer />
-      <WhatsAppButton />
+      <FabPortal>
+        <WhatsAppButton />
+      </FabPortal>
       {ENABLE_DZ_PARTICLES && showParticles && (
         <React.Suspense fallback={null}>
           <DarkZoneParticles />

--- a/src/components/FabPortal.tsx
+++ b/src/components/FabPortal.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+export default function FabPortal({ children }: { children: ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+
+  const root = typeof document !== "undefined" ? document.body : null;
+  if (!root) return <>{children}</>;
+
+  // Conteneur EXTERNE uniquement pour le positionnement (on NE touche PAS au bouton interne)
+  const container = (
+    <div className="fixed left-4 bottom-4 md:left-5 md:bottom-6 z-[9999] pointer-events-auto">
+      {children}
+    </div>
+  );
+  return createPortal(container, root);
+}


### PR DESCRIPTION
## Summary
- add `FabPortal` component to render floating elements at the end of `body`
- wrap existing WhatsApp FAB in `FabPortal` so it stays fixed above the footer without altering its design or link

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6898b331b8bc8331bf277085ab33a484