### PR TITLE
fix: improve mobile responsiveness

### DIFF
--- a/responsive_report/BEFORE_AFTER.md
+++ b/responsive_report/BEFORE_AFTER.md
@@ -1,0 +1,21 @@
+# Mobile Responsive Adjustments
+
+## Navigation (Header)
+- **Before:** Social links crowded header on small screens; no mobile menu.
+- **After:** Social links hidden on mobile with a new accessible menu button opening a vertical drawer. Header container now uses consistent padding and higher z-index.
+
+## Hero
+- **Before:** Hero section forced `min-h-screen`; video wrapper had fixed heights and caused horizontal padding issues.
+- **After:** Min height removed on mobile, container standardized, video wrapper uses fluid sizing with `object-cover` and padding, ensuring no overflow.
+
+## About Section
+- **Before:** Custom max-width container and large gaps created layout issues on narrow screens.
+- **After:** Standard `container` sizing with adaptive grid gaps and fluid typography for heading and paragraph.
+
+## Orbiting Labels
+- **Before:** Labels positioned absolutely around the planet on all breakpoints, causing overlap on small devices.
+- **After:** On mobile, labels stack vertically with 44px touch targets while orbital animation persists on larger screens.
+
+## Footer
+- **Before:** Flex layout could wrap awkwardly and email text could overflow.
+- **After:** Responsive grid layout with truncated email link and consistent padding; social links remain accessible.

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -10,15 +10,15 @@ interface AboutSectionProps {
 export function AboutSection({ t, isRTL }: AboutSectionProps) {
   return (
     <section id="about" className="py-10 md:py-20 bg-white dz-bg dz-fg">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-12 items-center">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-10 items-center">
           <motion.div
             initial={{ opacity: 0, x: isRTL ? 50 : -50 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.8 }}
           >
-            <h2 className="fs-xl md:text-4xl font-bold text-black mb-6 break-words dz-fg">
+            <h2 className="text-[clamp(1.3rem,3.5vw,1.875rem)] font-bold text-black mb-6 break-words dz-fg">
               {t.about.title}
             </h2>
           </motion.div>
@@ -29,7 +29,7 @@ export function AboutSection({ t, isRTL }: AboutSectionProps) {
             viewport={{ once: true }}
             transition={{ duration: 0.8, delay: 0.2 }}
           >
-            <p className="fs-base text-neutral-600 leading-relaxed break-words dz-fg">
+            <p className="text-[clamp(0.95rem,2.6vw,1.05rem)] leading-relaxed break-words hyphens-auto text-neutral-600 dz-fg">
               {t.about.content}
             </p>
           </motion.div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,12 +4,12 @@ import SocialLinks from '@/components/SocialLinks';
 export function Footer() {
   return (
     <footer id="site-footer" className="bg-black text-white py-6">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex flex-col sm:flex-row justify-between items-start gap-6 text-sm">
-        <div className="flex flex-col gap-2 w-full sm:w-auto">
-          <p className="break-words">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8 grid grid-cols-1 sm:grid-cols-2 gap-4 items-start text-sm">
+        <div className="flex flex-col gap-2 w-full min-w-0">
+          <p className="break-words truncate">
             <a
               href="mailto:contact@krglobalsolutionsltd.com"
-              className="underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
+              className="block truncate break-all underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
               aria-label="Envoyer un e-mail à contact@krglobalsolutionsltd.com"
             >
               contact@krglobalsolutionsltd.com
@@ -22,7 +22,7 @@ export function Footer() {
             Mentions légales
           </a>
         </div>
-        <div className="flex flex-col sm:items-end gap-2 w-full sm:w-auto">
+        <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
           <SocialLinks variant="footer" size={22} className="justify-center sm:justify-end" />
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import SocialLinks from "@/components/SocialLinks";
 import { Language, Translation } from '../data/translations';
 import KRLogoKR from "@/components/KRLogoKR";
 import { DarkZoneToggle } from './DarkZoneToggle';
+import { Menu, X } from "lucide-react";
 
 interface HeaderProps {
   currentLanguage: Language;
@@ -12,9 +13,10 @@ interface HeaderProps {
 }
 
 export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
+  const [open, setOpen] = React.useState(false);
   return (
-    <header className="sticky top-0 z-40 bg-white/80 backdrop-blur-md border-b border-neutral-200 dz-card dz-border dz-fg">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+    <header className="sticky top-0 z-[100] bg-white/80 backdrop-blur-md border-b border-neutral-200 dz-card dz-border dz-fg">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8 h-16 flex items-center justify-between">
         <div className="flex items-center gap-3 min-w-0">
           <KRLogoKR
             intensity="max"
@@ -29,10 +31,22 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
           {/* SAFE-GUARD: isolated toggle to avoid interfering with existing nav */}
           <DarkZoneToggle label={t.nav.darkZone} />
         </div>
-        <div className="flex items-center justify-end flex-1 overflow-hidden">
-          <SocialLinks variant="header" size={20} className="justify-end" />
+        <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
+          <SocialLinks variant="header" size={20} className="justify-end hidden md:flex" />
+          <button
+            className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50"
+            onClick={() => setOpen((o) => !o)}
+            aria-label={open ? 'Fermer le menu' : 'Menu'}
+          >
+            {open ? <X size={20} /> : <Menu size={20} />}
+          </button>
         </div>
       </div>
+      {open && (
+        <nav className="md:hidden border-t border-neutral-200 dz-border bg-white dz-card">
+          <SocialLinks variant="header" size={20} className="flex-col items-start p-4 gap-2" />
+        </nav>
+      )}
     </header>
   );
 }

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -47,8 +47,8 @@ export function HeroSection({ t }: HeroSectionProps) {
   // const currentRadius = radius - 20 * proximity;
 
   return (
-    <section className="min-h-screen flex items-center justify-center py-10 sm:py-20 bg-gradient-to-br from-white to-neutral-50 dz-bg dz-fg">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+    <section className="flex items-center justify-center py-10 sm:py-20 bg-gradient-to-br from-white to-neutral-50 dz-bg dz-fg md:min-h-screen">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8 text-center">
         {/* Title and Subtitle */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -57,7 +57,7 @@ export function HeroSection({ t }: HeroSectionProps) {
           className="mb-16"
         >
           <InfiniteHeadline />
-          <p className="mt-6 fs-base md:text-xl text-neutral-600 max-w-3xl mx-auto break-words">
+          <p className="mt-6 text-[clamp(0.95rem,2.6vw,1.05rem)] leading-relaxed text-neutral-600 max-w-3xl mx-auto break-words hyphens-auto">
             {t.hero.subtitle}
           </p>
 
@@ -72,7 +72,7 @@ export function HeroSection({ t }: HeroSectionProps) {
           initial={{ opacity: 0, scale: 0.8 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ duration: 1, delay: 0.3 }}
-          className="relative mx-auto mb-16 w-72 h-72 sm:w-80 sm:h-80 mt-14 md:mt-20 lg:mt-24"
+          className="relative mx-auto mb-16 w-full max-w-[18rem] aspect-square sm:max-w-[20rem] mt-14 md:mt-20 lg:mt-24"
         >
           {/* <div className="absolute inset-0 animate-orbit will-change-transform">
             {orbitalButtons.map((button, index) => {

--- a/src/components/HeroVideoCompat.tsx
+++ b/src/components/HeroVideoCompat.tsx
@@ -58,12 +58,12 @@ export default function HeroVideoCompat() {
   const mark = () => setStarted(true);
 
   return (
-    <div className="relative w-full aspect-video min-h-[260px] sm:min-h-[360px] overflow-hidden rounded-xl bg-black">
+    <div className="relative w-full overflow-hidden px-4 aspect-video rounded-xl bg-black">
       {/* Skeleton noir tant que la lecture n’a pas démarré */}
       {!started && <div aria-hidden className="absolute inset-0 bg-black z-0" />}
       <video
         ref={vref}
-        className="w-full h-full object-cover z-[1]"
+        className="w-full h-auto object-cover md:object-contain z-[1]"
         autoPlay
         muted
         loop

--- a/src/components/OrbitMenuDynamic.tsx
+++ b/src/components/OrbitMenuDynamic.tsx
@@ -67,39 +67,56 @@ export default function OrbitMenuDynamic({
   }, [items.length, gap, baseRadius.sm, baseRadius.md, baseRadius.lg]);
 
   return (
-    <div
-      ref={containerRef}
-      className={`relative flex items-center justify-center ${className}`}
-      onMouseEnter={() => setActive(-1)}
-      onMouseLeave={() => setActive(null)}
-    >
-      <div className="orbit-rotor">
-        {items.map((it, i) => (
-          <OrbitItem
-            key={i}
-            refEl={(el) => (itemRefs.current[i] = el)}
-            angle={angles[i]}
-            label={it.label}
-            href={it.href}
-            external={it.external}
-            ariaLabel={it.ariaLabel ?? it.label}
-            r={radius.lg}
-            active={active === i}
-            setActive={setActive}
-          />
-        ))}
+    <div className={`flex md:block flex-col items-center gap-3 md:gap-0 ${className}`}>
+      <div
+        ref={containerRef}
+        className="relative hidden md:flex items-center justify-center"
+        onMouseEnter={() => setActive(-1)}
+        onMouseLeave={() => setActive(null)}
+      >
+        <div className="orbit-rotor">
+          {items.map((it, i) => (
+            <OrbitItem
+              key={i}
+              refEl={(el) => (itemRefs.current[i] = el)}
+              angle={angles[i]}
+              label={it.label}
+              href={it.href}
+              external={it.external}
+              ariaLabel={it.ariaLabel ?? it.label}
+              r={radius.lg}
+              active={active === i}
+              setActive={setActive}
+            />
+          ))}
+        </div>
+
+        <style jsx global>{`
+          @keyframes orbit-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+          .orbit-rotor {
+            position: absolute; inset: 0;
+            animation: orbit-spin 30s linear infinite;
+            will-change: transform;
+          }
+          .relative:hover .orbit-rotor, .relative:focus-within .orbit-rotor { animation-play-state: paused; }
+          @media (prefers-reduced-motion: reduce) { .orbit-rotor { animation: none; } }
+        `}</style>
       </div>
 
-      <style jsx global>{`
-        @keyframes orbit-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-        .orbit-rotor {
-          position: absolute; inset: 0;
-          animation: orbit-spin 30s linear infinite;
-          will-change: transform;
-        }
-        .relative:hover .orbit-rotor, .relative:focus-within .orbit-rotor { animation-play-state: paused; }
-        @media (prefers-reduced-motion: reduce) { .orbit-rotor { animation: none; } }
-      `}</style>
+      <div className="flex md:hidden flex-col items-center gap-3">
+        {items.map((it, i) => (
+          <a
+            key={i}
+            href={it.href}
+            aria-label={it.ariaLabel ?? it.label}
+            target={it.external ? '_blank' : undefined}
+            rel={it.external ? 'noopener noreferrer' : undefined}
+            className="min-h-11 px-4 rounded-full bg-white text-black shadow-md flex items-center justify-center w-full max-w-xs"
+          >
+            <span className="truncate">{it.label}</span>
+          </a>
+        ))}
+      </div>
     </div>
   );
 }
@@ -137,8 +154,8 @@ function OrbitItem({
           aria-label={ariaLabel}
           target={external ? '_blank' : undefined}
           rel={external ? 'noopener noreferrer' : undefined}
-          className="group inline-flex items-center justify-center rounded-2xl bg-white text-black shadow-md
-                     px-4 py-2 min-h-[40px] select-none transition-all duration-200 ease-out
+          className="group inline-flex items-center justify-center rounded-full bg-white text-black shadow-md
+                     px-4 py-2 min-h-11 select-none transition-all duration-200 ease-out
                      focus:outline-none focus-visible:ring-2 focus-visible:ring-black/30"
           onMouseEnter={() => setActive(1)}
           onMouseLeave={() => setActive(-1)}

--- a/src/components/WhatsAppButton.tsx
+++ b/src/components/WhatsAppButton.tsx
@@ -7,7 +7,7 @@ export default function WhatsAppButton() {
       target="_blank"
       rel="noopener noreferrer"
       aria-label="WhatsApp Business"
-      className="fixed z-[9999] left-[15px] bottom-[15px] md:left-5 md:bottom-5 rounded-full shadow-lg px-4 py-3 bg-black text-white hover:opacity-90 transition"
+      className="rounded-full shadow-lg px-4 py-3 bg-black text-white hover:opacity-90 transition"
     >
       WhatsApp
     </a>

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,22 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Preflight anti-overflow for mobile */
+html,
+body {
+  overflow-x: hidden;
+}
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+* {
+  min-width: 0;
+}
+
 /* Base Styles */
 html {
   scroll-behavior: smooth;


### PR DESCRIPTION
## Summary
- add mobile overflow preflight and fluid containers
- implement mobile menu, fluid hero/video, and responsive orbit labels
- standardize footer grid and typography for small screens

## Testing
- `npm run check:mobile`

------
https://chatgpt.com/codex/tasks/task_b_6898b61afe5883319dd21aadbcc97c05