### PR TITLE
fix(desktop): WhatsApp FAB stays fixed on scroll-up

### DIFF
--- a/src/components/FabPortal.tsx
+++ b/src/components/FabPortal.tsx
@@ -1,19 +1,67 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
+
+function useFixedFabOnDesktop(ref: React.RefObject<HTMLElement>) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const apply = () => {
+      // forcer la position à chaque frame de scroll (corrige le bug en scroll-up)
+      el.style.position = "fixed";
+      el.style.transform = "translate3d(0,0,0)";
+      if (window.innerWidth >= 1024) {
+        el.style.left = "20px";
+        el.style.bottom = "24px";
+      } else {
+        // ne pas casser le mobile, valeurs soft (peu utilisées car hook desktop)
+        el.style.left = "16px";
+        el.style.bottom = "16px";
+      }
+      el.style.zIndex = "2147483647";
+      el.style.pointerEvents = "auto";
+    };
+
+    let raf = 0;
+    const onScroll = () => { cancelAnimationFrame(raf); raf = requestAnimationFrame(apply); };
+    const onResize = onScroll;
+
+    apply(); // init
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onResize);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onResize);
+    };
+  }, [ref]);
+}
 
 export default function FabPortal({ children }: { children: ReactNode }) {
   const [mounted, setMounted] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
   useEffect(() => setMounted(true), []);
-  if (!mounted) return null;
+  useFixedFabOnDesktop(ref);
 
+  if (!mounted) return null;
   const root = typeof document !== "undefined" ? document.body : null;
   if (!root) return <>{children}</>;
 
-  // Conteneur EXTERNE uniquement pour le positionnement (on NE touche PAS au bouton interne)
-  const container = (
-    <div className="fixed left-4 bottom-4 md:left-5 md:bottom-6 z-[9999] pointer-events-auto">
+  // Wrapper externe UNIQUEMENT (on ne touche pas au bouton interne)
+  return createPortal(
+    <div
+      ref={ref}
+      className="kr-wa-fab"
+      style={{
+        // éviter les transitions foireuses sur la position
+        transitionProperty: "none",
+        // safe area iOS (n'influe pas desktop mais inoffensif)
+        bottom: "calc(1rem + env(safe-area-inset-bottom, 0px))",
+        left: "1rem",
+      }}
+    >
       {children}
-    </div>
+    </div>,
+    root
   );
-  return createPortal(container, root);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 /* Font Import */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
+@import './styles/globals.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,12 @@
+/* neutraliser d’éventuelles règles qui cassent le fixed */
+.kr-wa-fab {
+  contain: layout style size;
+}
+@media (min-width: 1024px) {
+  html, body {
+    transform: none !important;
+    filter: none !important;
+    perspective: none !important;
+    backdrop-filter: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure WhatsApp FAB uses a portal with a RAF scroll/resize fallback to stay fixed on desktop
- add global CSS safeguards to prevent transforms from breaking fixed position

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6898ba9087a883319e36c7140a8448d5