### PR TITLE
feat: update whatsapp button link and style

### DIFF
--- a/src/components/WhatsAppButton.tsx
+++ b/src/components/WhatsAppButton.tsx
@@ -3,21 +3,17 @@
 import React from "react";
 
 type Props = {
-  phone?: string;
-  message?: string;
   showOnMobile?: boolean;
   showOnDesktop?: boolean;
   ariaLabel?: string;
 };
 
 export default function WhatsAppButton({
-  phone = process.env.NEXT_PUBLIC_WAPP_PHONE || "33781579222",
-  message = "Bonjour ! Je viens du site KR Global Solutions et j’aimerais en savoir plus.",
   showOnMobile = true,
   showOnDesktop = true,
-  ariaLabel = "Contacter sur WhatsApp",
+  ariaLabel = "Contact WhatsApp",
 }: Props) {
-  const href = `https://wa.me/${phone}?text=${encodeURIComponent(message)}`;
+  const href = process.env.NEXT_PUBLIC_WHATSAPP_URL || "https://wa.me/33743561304";
 
   const visibility =
     (showOnMobile ? "" : " hidden sm:inline") +
@@ -32,22 +28,15 @@ export default function WhatsAppButton({
         target="_blank"
         rel="noopener noreferrer"
         aria-label={ariaLabel}
-        className="pointer-events-auto group inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 rounded-full shadow-xl ring-1 ring-black/10 dark:ring-white/10 bg-white/90 dark:bg-neutral-900/90 backdrop-blur-xl transition-transform duration-200 hover:scale-105"
+        className="pointer-events-auto relative w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-black text-white shadow-lg border border-white/10 flex items-center justify-center transition hover:shadow-2xl hover:scale-105 active:scale-95"
       >
-        <svg
-          viewBox="0 0 32 32"
-          className="w-8 h-8 sm:w-9 sm:h-9 text-green-500 dark:text-green-400"
-        >
-          <path
-            d="M19.11 17.52c-.29-.14-1.7-.84-1.96-.94-.26-.1-.45-.14-.64.14s-.73.94-.89 1.13-.33.21-.61.07a7.69 7.69 0 0 1-2.27-1.4 8.5 8.5 0 0 1-1.57-1.95c-.16-.27 0-.41.12-.55.12-.12.26-.33.39-.5a1.8 1.8 0 0 0 .26-.48.5.5 0 0 0 0-.48c0-.14-.64-1.54-.88-2.12-.23-.56-.47-.49-.64-.49h-.55a1 1 0 0 0-.73.34A3 3 0 0 0 7 11.3a5.19 5.19 0 0 0 1.09 2.77 11.85 11.85 0 0 0 4.54 4.12 15.51 15.51 0 0 0 1.55.57 3.74 3.74 0 0 0 1.71.11 2.79 2.79 0 0 0 1.83-1.27 2.25 2.25 0 0 0 .16-1.25c-.06-.12-.22-.18-.37-.27Z"
-            fill="currentColor"
-          />
-          <path
-            d="M26.85 5.15A13.9 13.9 0 0 0 4.26 22.54L3 29l6.6-1.73A13.9 13.9 0 0 0 28.2 16a13.8 13.8 0 0 0-1.35-10.85Zm-1.88 16.56a11.39 11.39 0 0 1-9.21 3.11 11.45 11.45 0 0 1-4.89-1.48l-.35-.19-3.92 1 1-3.82-.2-.39a11.34 11.34 0 0 1 1.6-13.63 11.33 11.33 0 0 1 19 9.4 11.26 11.26 0 0 1-2.99 6.02Z"
-            fill="currentColor"
-          />
+        {/* Icône WhatsApp (blanc via currentColor) */}
+        <svg viewBox="0 0 32 32" className="w-6 h-6" fill="currentColor" aria-hidden="true">
+          <path d="M19.11 17.38c-.28-.14-1.64-.8-1.9-.89-.26-.1-.45-.14-.64.14-.19.28-.73.89-.9 1.07-.17.19-.33.21-.61.07-.28-.14-1.18-.44-2.24-1.4-.83-.74-1.39-1.65-1.56-1.93-.17-.28-.02-.43.12-.57.12-.12.28-.33.42-.5.14-.17.19-.28.28-.47.09-.19.05-.35-.02-.49-.07-.14-.64-1.54-.87-2.11-.23-.55-.47-.47-.64-.47h-.55c-.19 0-.49.07-.75.35-.26.28-1 1-1 2.43 0 1.42 1.02 2.8 1.16 2.99.14.19 2.01 3.16 4.86 4.43.68.29 1.21.46 1.62.59.68.22 1.31.19 1.8.12.55-.08 1.64-.67 1.87-1.32.23-.65.23-1.21.16-1.32-.07-.12-.26-.19-.54-.33zM16.02 4C9.94 4 5 8.93 5 15.01c0 1.94.5 3.76 1.37 5.35L5 28l7.82-2.06c1.55.85 3.33 1.35 5.2 1.35 6.08 0 11.02-4.94 11.02-11.02C29.04 8.93 24.1 4 18.02 4h-1.99zM18 25.11c-1.67 0-3.23-.49-4.53-1.33l-.33-.21-4.64 1.23 1.24-4.52-.22-.35A8.9 8.9 0 0 1 7.9 15c0-4.47 3.63-8.1 8.1-8.1 4.47 0 8.1 3.63 8.1 8.1 0 4.48-3.63 8.11-8.1 8.11z" />
         </svg>
-        <span className="absolute -top-1 -right-1 h-3 w-3 rounded-full bg-green-500 dark:bg-green-400 shadow group-hover:scale-110 transition-transform" />
+
+        {/* point "online" optionnel - supprimer si 100% monochrome */}
+        <span className="absolute -right-0.5 -top-0.5 w-2.5 h-2.5 rounded-full bg-emerald-500 ring-2 ring-black" />
       </a>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace WhatsApp link with environment-configurable business URL
- restyle floating button with black round background, white icon, and hover effects

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6898bff504888331bb0d20fc1314764a