### PR TITLE
feat: add scroll targeting and FAQ accordion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,9 +42,9 @@ function App() {
 
       <main>
         <HeroSection t={t} />
+        <RotatingLinks />
         <PricingSection />
         <QuizPack />
-        <RotatingLinks />
         <FAQSection />
         <AboutSection t={t} isRTL={isRTL} />
       </main>

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -1,22 +1,51 @@
 "use client";
+import { useState } from "react";
+
+type QA = { q: string; a: string };
+
+const ITEMS: QA[] = [
+  { q: "Comment choisir le bon pack ?", a: "Remplissez le formulaire 'Quel pack...' juste au-dessus : 4 champs rapides. Sinon, contactez-nous pour un devis express." },
+  { q: "Les tarifs sont-ils fixes ?", a: "Ils sont 'à partir de'. On ajuste selon votre contexte (périmètre, délais, complexité)." },
+  { q: "Proposez-vous la livraison express ?", a: "Oui, en option sur certains livrables (à préciser lors de la prise de brief)." },
+  { q: "Paiement en plusieurs fois ?", a: "Oui, disponible pour les packs Croissance & Sur‑mesure." },
+];
+
 export default function FAQSection() {
-  const items = [
-    { q: "Comment choisir le bon pack ?", a: "Utilisez le quiz (3 questions) ou contactez-nous pour un devis express." },
-    { q: "Les tarifs sont-ils fixes ?", a: "Ils sont 'à partir de'. Nous ajustons selon votre contexte et vos besoins." },
-    { q: "Proposez-vous la livraison express ?", a: "Oui, possible en option sur certains livrables." },
-    { q: "Puis-je payer en plusieurs fois ?", a: "Oui, paiement fractionné disponible sur les packs Croissance/Sur-mesure." },
-  ];
+  const [open, setOpen] = useState<number | null>(null);
+
   return (
-    <section className="w-full bg-[#0B0B0C] py-12">
+    <section className="w-full bg-white py-12">
       <div className="mx-auto max-w-4xl px-4">
-        <h2 className="mb-6 text-2xl font-extrabold text-white">FAQ</h2>
+        <h2 className="mb-6 text-2xl font-extrabold text-black">FAQ</h2>
         <ul className="space-y-3">
-          {items.map((it, i) => (
-            <li key={i} className="rounded-2xl border border-white/10 bg-white/5 p-4">
-              <p className="text-sm font-semibold text-white">{it.q}</p>
-              <p className="mt-1 text-sm text-gray-300">{it.a}</p>
-            </li>
-          ))}
+          {ITEMS.map((it, i) => {
+            const isOpen = open === i;
+            return (
+              <li key={i} className="rounded-2xl border border-black/10 bg-black/[0.03]">
+                <button
+                  onClick={() => setOpen(isOpen ? null : i)}
+                  aria-expanded={isOpen}
+                  className="flex w-full items-center justify-between px-4 py-3 text-left"
+                >
+                  <span className="text-sm font-semibold text-black">{it.q}</span>
+                  <span
+                    aria-hidden
+                    className="ml-3 inline-flex h-6 w-6 items-center justify-center rounded-md border border-black/10 bg-white text-black"
+                  >
+                    {isOpen ? "–" : "+"}
+                  </span>
+                </button>
+
+                <div
+                  className={`px-4 pt-0 transition-all duration-200 ease-out ${
+                    isOpen ? "max-h-40 pb-4" : "max-h-0 overflow-hidden"
+                  }`}
+                >
+                  <p className="text-sm text-neutral-700">{it.a}</p>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       </div>
     </section>

--- a/src/components/pricing/InlineInquiryForm.tsx
+++ b/src/components/pricing/InlineInquiryForm.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { useState } from "react";
+
+export default function InlineInquiryForm() {
+  const [values, setValues] = useState({ name: "", email: "", goal: "", budget: "" });
+  const update = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setValues((v) => ({ ...v, [name]: value }));
+  };
+  return (
+    <form className="mx-auto mb-8 max-w-xl text-gray-200">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <input
+          name="name"
+          value={values.name}
+          onChange={update}
+          placeholder="Votre nom"
+          className="rounded-lg border border-white/20 bg-white/5 px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-white/40"
+        />
+        <input
+          name="email"
+          type="email"
+          value={values.email}
+          onChange={update}
+          placeholder="Email"
+          className="rounded-lg border border-white/20 bg-white/5 px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-white/40"
+        />
+        <input
+          name="goal"
+          value={values.goal}
+          onChange={update}
+          placeholder="Votre objectif"
+          className="rounded-lg border border-white/20 bg-white/5 px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-white/40"
+        />
+        <input
+          name="budget"
+          value={values.budget}
+          onChange={update}
+          placeholder="Budget estimé"
+          className="rounded-lg border border-white/20 bg-white/5 px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-white/40"
+        />
+      </div>
+      <button
+        type="submit"
+        className="mt-3 inline-flex h-10 w-full items-center justify-center rounded-xl border border-white/30 px-4 text-sm font-semibold text-white transition-all hover:bg-white hover:text-black"
+      >
+        Envoyer
+      </button>
+    </form>
+  );
+}

--- a/src/components/pricing/PricingSection.tsx
+++ b/src/components/pricing/PricingSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { motion } from "framer-motion";
+import InlineInquiryForm from "./InlineInquiryForm";
 import { CALENDAR_URL, WHATSAPP_NUMBER, WHATSAPP_MSG_DEFAULT } from "@/lib/siteConfig";
 
 type Feature = { label: string };
@@ -127,13 +128,16 @@ function Card({
   plan,
   open,
   onToggle,
+  htmlId,
 }: {
   plan: Plan;
   open: boolean;
   onToggle: () => void;
+  htmlId: string;
 }) {
   return (
     <motion.article
+      id={htmlId}
       className="relative flex flex-col justify-between rounded-2xl border border-[#2A2A2A] bg-[#121212] p-5 shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_12px_36px_rgba(0,0,0,0.35)] hover:outline hover:outline-1 hover:outline-white/10"
       initial={{ opacity: 0, y: 18 }}
       whileInView={{ opacity: 1, y: 0 }}
@@ -237,6 +241,7 @@ function Card({
 export default function PricingSection() {
   const [openId, setOpenId] = useState<string | null>(null);
   const toggle = (id: string) => setOpenId((cur) => (cur === id ? null : id));
+  const [showForm, setShowForm] = useState(false);
 
   return (
     <section aria-labelledby="pricing-title" className="w-full bg-[#0B0B0C] py-12">
@@ -255,17 +260,26 @@ export default function PricingSection() {
           <p className="mx-auto mt-2 max-w-2xl text-sm text-gray-300">
             Choisissez un pack selon votre objectif. Les tarifs sont “à partir de” et ajustés selon votre contexte.
           </p>
-          <a
-            href="#quiz-pack"
+          <button
+            onClick={() => setShowForm((v) => !v)}
             className="mt-3 inline-flex h-9 items-center justify-center rounded-lg border border-white/15 bg-white/5 px-3 text-xs text-gray-200 hover:bg-white hover:text-black"
+            aria-expanded={showForm}
           >
             🔎 Quel pack est fait pour vous ?
-          </a>
+          </button>
         </header>
+
+        {showForm && <InlineInquiryForm />}
 
         <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
           {plans.map((p) => (
-            <Card key={p.id} plan={p} open={openId === p.id} onToggle={() => toggle(p.id)} />
+            <Card
+              key={p.id}
+              plan={p}
+              open={openId === p.id}
+              onToggle={() => toggle(p.id)}
+              htmlId={`plan-${p.id}`}
+            />
           ))}
         </div>
 

--- a/src/components/pricing/QuizPack.tsx
+++ b/src/components/pricing/QuizPack.tsx
@@ -37,6 +37,11 @@ function waHref(planName: string) {
   return `https://wa.me/${n}?text=${msg}`;
 }
 
+function scrollToId(id: string) {
+  const el = document.getElementById(id);
+  if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
 export default function QuizPack() {
   const [step, setStep] = useState(0);
   const [scores, setScores] = useState<{ [k in PlanId]: number }>({
@@ -55,8 +60,6 @@ export default function QuizPack() {
     const plan = (Object.keys(scores) as PlanId[]).reduce((a, b) => (scores[b] > scores[a] ? b : a), "starter");
     const planLabel =
       plan === "starter" ? "Pack Découverte" : plan === "growth" ? "Pack Croissance" : "Pack Sur‑mesure";
-    const href =
-      plan === "starter" ? "#commande-starter" : plan === "growth" ? "#commande-growth" : "#devis-sur-mesure";
     return (
       <section id="quiz-pack" className="w-full bg-[#0B0B0C] py-12">
         <div className="mx-auto max-w-3xl px-4 text-center text-gray-200">
@@ -65,12 +68,12 @@ export default function QuizPack() {
             Nous vous conseillons le <span className="font-semibold">{planLabel}</span>.
           </p>
           <div className="flex justify-center gap-3">
-            <a
-              href={href}
+            <button
+              onClick={() => scrollToId(`plan-${plan}`)}
               className="inline-flex h-10 items-center justify-center rounded-lg border border-white/30 px-4 text-sm font-semibold text-white hover:bg-white hover:text-black"
             >
               Voir le pack
-            </a>
+            </button>
             <a
               href={waHref(planLabel)}
               target="_blank"


### PR DESCRIPTION
## Summary
- keep rotating links only after hero
- add anchor ids to pricing cards with inline pack inquiry form
- allow recommended pack button to smoothly scroll to plan
- replace FAQ with white accordion layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689ae2d8cb848331b4356ca953ad215a