### PR TITLE
feat: streamline offers CTA and remove outdated elements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import { Header } from './components/Header';
 import { HeroSection } from './components/HeroSection';
 import PricingSection from '@/components/pricing/PricingSection';
 import QuizPack from '@/components/pricing/QuizPack';
-import RotatingLinks from '@/components/RotatingLinks';
 import FAQSection from '@/components/FAQSection';
 import { AboutSection } from './components/AboutSection';
 import { Footer } from './components/Footer';
@@ -42,7 +41,6 @@ function App() {
 
       <main>
         <HeroSection t={t} />
-        <RotatingLinks />
         <PricingSection />
         <QuizPack />
         <FAQSection />

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -54,7 +54,7 @@ export function HeroSection({ t }: HeroSectionProps) {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8 }}
-          className="mb-16"
+          className="mb-8"
         >
           <InfiniteHeadline />
           <p className="mt-6 text-[clamp(0.95rem,2.6vw,1.05rem)] leading-relaxed text-neutral-600 max-w-3xl mx-auto break-words hyphens-auto">
@@ -72,7 +72,7 @@ export function HeroSection({ t }: HeroSectionProps) {
           initial={{ opacity: 0, scale: 0.8 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ duration: 1, delay: 0.3 }}
-          className="relative mx-auto mb-16 w-full max-w-[18rem] aspect-square sm:max-w-[20rem] mt-14 md:mt-20 lg:mt-24"
+          className="relative mx-auto mb-8 w-full max-w-[18rem] aspect-square sm:max-w-[20rem] mt-8 md:mt-12 lg:mt-16"
         >
           {/* <div className="absolute inset-0 animate-orbit will-change-transform">
             {orbitalButtons.map((button, index) => {

--- a/src/components/HeroVideoCompat.tsx
+++ b/src/components/HeroVideoCompat.tsx
@@ -58,12 +58,12 @@ export default function HeroVideoCompat() {
   const mark = () => setStarted(true);
 
   return (
-    <div className="relative w-full overflow-hidden px-4 aspect-video rounded-xl bg-black">
+    <div className="relative w-full overflow-hidden px-4 aspect-video rounded-xl bg-black max-h-[420px] md:max-h-[520px]">
       {/* Skeleton noir tant que la lecture n’a pas démarré */}
       {!started && <div aria-hidden className="absolute inset-0 bg-black z-0" />}
       <video
         ref={vref}
-        className="w-full h-auto object-cover md:object-contain z-[1]"
+        className="w-full h-full object-cover md:object-contain z-[1]"
         autoPlay
         muted
         loop

--- a/src/components/RotatingLinks.tsx
+++ b/src/components/RotatingLinks.tsx
@@ -3,7 +3,12 @@ import OrbitMenuDynamic from "@/components/OrbitMenuDynamic";
 import { socialLinks } from "@/components/SocialLinks";
 
 export default function RotatingLinks() {
-  const items = socialLinks.map((s) => ({ label: s.label, href: s.href, external: true, ariaLabel: s.label }));
+  const isSocial = (href: string) =>
+    /instagram\.com|tiktok\.com|linkedin\.com|github\.com|fiverr\.com/i.test(href);
+  const items = socialLinks
+    .filter((s) => !isSocial(s.href))
+    .map((s) => ({ label: s.label, href: s.href, external: true, ariaLabel: s.label }));
+  if (items.length === 0) return null;
   return (
     <section className="w-full bg-[#0B0B0C] py-12">
       <div className="relative mx-auto flex h-64 w-full max-w-xl items-center justify-center">

--- a/src/components/pricing/PricingSection.tsx
+++ b/src/components/pricing/PricingSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useState } from "react";
 import { motion } from "framer-motion";
-import InlineInquiryForm from "./InlineInquiryForm";
 import { CALENDAR_URL, WHATSAPP_NUMBER, WHATSAPP_MSG_DEFAULT } from "@/lib/siteConfig";
 
 type Feature = { label: string };
@@ -103,8 +102,6 @@ const plans: Plan[] = [
   },
 ];
 
-const PROMO_ENABLED = true;
-const PROMO_TEXT = "Offre limitée : livraison express offerte jusqu’au 30/09";
 
 const wa = (msg?: string) => {
   const n = WHATSAPP_NUMBER.replace(/\D/g, "");
@@ -241,17 +238,10 @@ function Card({
 export default function PricingSection() {
   const [openId, setOpenId] = useState<string | null>(null);
   const toggle = (id: string) => setOpenId((cur) => (cur === id ? null : id));
-  const [showForm, setShowForm] = useState(false);
 
   return (
-    <section aria-labelledby="pricing-title" className="w-full bg-[#0B0B0C] py-12">
+    <section aria-labelledby="pricing-title" className="w-full bg-[#0B0B0C] pt-8 pb-12">
       <div className="mx-auto max-w-6xl px-4">
-
-        {PROMO_ENABLED && (
-          <div className="mb-6 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-center text-sm text-gray-200">
-            {PROMO_TEXT}
-          </div>
-        )}
 
         <header className="mb-8 text-center">
           <h2 id="pricing-title" className="text-3xl font-extrabold tracking-tight text-white">
@@ -261,15 +251,17 @@ export default function PricingSection() {
             Choisissez un pack selon votre objectif. Les tarifs sont “à partir de” et ajustés selon votre contexte.
           </p>
           <button
-            onClick={() => setShowForm((v) => !v)}
+            onClick={() => {
+              const el = document.querySelector('#pack-quiz');
+              if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              if (history?.replaceState) history.replaceState(null, '', '#pack-quiz');
+            }}
             className="mt-3 inline-flex h-9 items-center justify-center rounded-lg border border-white/15 bg-white/5 px-3 text-xs text-gray-200 hover:bg-white hover:text-black"
-            aria-expanded={showForm}
+            aria-controls="pack-quiz"
           >
-            🔎 Quel pack est fait pour vous ?
+            Quel pack est fait pour vous ?
           </button>
         </header>
-
-        {showForm && <InlineInquiryForm />}
 
         <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
           {plans.map((p) => (

--- a/src/components/pricing/QuizPack.tsx
+++ b/src/components/pricing/QuizPack.tsx
@@ -61,8 +61,9 @@ export default function QuizPack() {
     const planLabel =
       plan === "starter" ? "Pack Découverte" : plan === "growth" ? "Pack Croissance" : "Pack Sur‑mesure";
     return (
-      <section id="quiz-pack" className="w-full bg-[#0B0B0C] py-12">
+      <section className="w-full bg-[#0B0B0C] py-12">
         <div className="mx-auto max-w-3xl px-4 text-center text-gray-200">
+          <span id="pack-quiz" className="block relative -top-20" />
           <h2 className="text-2xl font-bold text-white mb-4">Votre pack recommandé</h2>
           <p className="mb-6">
             Nous vous conseillons le <span className="font-semibold">{planLabel}</span>.
@@ -89,8 +90,10 @@ export default function QuizPack() {
   }
 
   return (
-    <section id="quiz-pack" className="w-full bg-[#0B0B0C] py-12">
+    <section className="w-full bg-[#0B0B0C] py-12">
       <div className="mx-auto max-w-3xl px-4 text-center text-gray-200">
+        {/* anchor for smooth scroll from Offres CTA */}
+        <span id="pack-quiz" className="block relative -top-20" />
         <h2 className="text-2xl font-bold text-white mb-6">Quel pack est fait pour vous ?</h2>
         <p className="mb-4 text-sm">{current.q}</p>
         <div className="flex flex-col items-center gap-3">


### PR DESCRIPTION
## Summary
- link offers CTA to existing pack quiz and drop old lead form
- remove rotating social links and limited-time promo banner
- cap hero video height and tighten spacing before pricing cards

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_689ae6fa76ec8331a60ccec06129a06a