### PR TITLE
feat(faq): enrichissement contenu FR — design et structure inchangés

### DIFF
--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -4,10 +4,70 @@ import { useState } from "react";
 type QA = { q: string; a: string };
 
 const ITEMS: QA[] = [
-  { q: "Comment choisir le bon pack ?", a: "Remplissez le formulaire 'Quel pack...' juste au-dessus : 4 champs rapides. Sinon, contactez-nous pour un devis express." },
-  { q: "Les tarifs sont-ils fixes ?", a: "Ils sont 'à partir de'. On ajuste selon votre contexte (périmètre, délais, complexité)." },
-  { q: "Proposez-vous la livraison express ?", a: "Oui, en option sur certains livrables (à préciser lors de la prise de brief)." },
-  { q: "Paiement en plusieurs fois ?", a: "Oui, disponible pour les packs Croissance & Sur‑mesure." },
+  {
+    q: "Comment choisir le pack qui correspond le mieux à mes besoins ?",
+    a: "Nous analysons vos objectifs, votre budget et votre activité afin de recommander la formule la plus pertinente pour atteindre vos résultats rapidement.",
+  },
+  {
+    q: "Les tarifs indiqués sont-ils fixes ou peuvent-ils varier ?",
+    a: "Les tarifs sont fixes par pack. En cas de besoin spécifique (fonctionnalités sur mesure, intégrations complexes), un devis personnalisé peut être proposé.",
+  },
+  {
+    q: "Proposez-vous une mise en ligne ou une livraison express ?",
+    a: "Oui. L’option Express accélère la production et la mise en ligne — idéale pour un lancement urgent, sous réserve de disponibilité planning.",
+  },
+  {
+    q: "Puis-je payer en plusieurs fois ?",
+    a: "Oui, le paiement échelonné est disponible pour les packs Croissance et Sur‑mesure, sans frais cachés.",
+  },
+  {
+    q: "Pouvez-vous personnaliser entièrement mon projet ?",
+    a: "Absolument. Nous concevons des solutions 100 % adaptées à vos objectifs, à votre identité de marque et à vos contraintes métier.",
+  },
+  {
+    q: "Y a‑t‑il un accompagnement après la livraison ?",
+    a: "Oui. Nous proposons un support post‑livraison (assistance technique, correctifs, petites évolutions) et des options de maintenance.",
+  },
+  {
+    q: "Puis-je demander des modifications après validation ?",
+    a: "Oui. Des ajustements sont possibles selon les conditions de votre pack et la fenêtre de retours prévue au contrat.",
+  },
+  {
+    q: "Travaillez-vous avec des particuliers ou uniquement des entreprises ?",
+    a: "Nous accompagnons les entreprises (TPE/PME/ETI), associations et indépendants/particuliers pour leurs projets digitaux et e‑commerce.",
+  },
+  {
+    q: "Créez-vous aussi le contenu (textes, visuels, vidéos) ?",
+    a: "Oui. Sur demande, nous produisons des textes optimisés, des visuels et des vidéos cohérents avec votre identité et vos objectifs.",
+  },
+  {
+    q: "Vos solutions sont‑elles compatibles mobile et tablette ?",
+    a: "Oui. Tous nos livrables sont conçus en responsive design pour une expérience optimale sur mobile, tablette et desktop.",
+  },
+  {
+    q: "Intervenez-vous à l’international ?",
+    a: "Oui. Nous gérons les projets à distance et collaborons avec des clients basés partout dans le monde.",
+  },
+  {
+    q: "Proposez-vous des formations pour utiliser les outils livrés ?",
+    a: "Oui. Nous offrons des sessions de prise en main personnalisées (en visio ou en présentiel) pour vous rendre autonome.",
+  },
+  {
+    q: "Avec quels outils/technologies travaillez-vous ?",
+    a: "Nous sélectionnons des technologies modernes et fiables (stack web actuelle, CMS/Headless, intégrations API) adaptées à votre contexte.",
+  },
+  {
+    q: "Quelles sont les étapes typiques d’un projet ?",
+    a: "Cadrage & objectifs, conception, design, développement/intégrations, tests & QA, mise en ligne, puis support/optimisation.",
+  },
+  {
+    q: "Quels délais prévoir pour un projet standard ?",
+    a: "Selon le pack et la complexité : de quelques jours (Express) à plusieurs semaines. Un planning précis est fourni au démarrage.",
+  },
+  {
+    q: "Puis-je migrer ou faire évoluer un projet existant ?",
+    a: "Oui. Nous auditons l’existant, proposons un plan de migration/amélioration et assurons la continuité de service.",
+  },
 ];
 
 export default function FAQSection() {

--- a/src/data/faq.config.ts
+++ b/src/data/faq.config.ts
@@ -1,8 +1,66 @@
 export const FAQ = [
-  { q: 'Délais de livraison ?', a: 'Essentiel 24–48h, Avancé 3–5 jours, Premium 7–14 jours.' },
-  { q: 'Révisions incluses ?', a: 'Essentiel 1, Avancé 2, Premium illimité 30 jours.' },
-  { q: 'Outils utilisés ?', a: 'IA & no‑code : ChatGPT, Canva, Framer/Webflow/WP, Zapier/Make, EmailJS, Stripe, Calendly.' },
-  { q: 'Limites ?', a: 'Pas de tournage, pas de dev backend lourd, pas de conseil juridique/fiscal.' },
-  { q: 'Paiements ?', a: 'Stripe (49/99), virement; acompte possible pour Premium.' },
-  { q: 'Support ?', a: 'Email (Essentiel), Email+WhatsApp (Avancé), Email+WhatsApp+Visio (Premium).' }
+  {
+    q: 'Comment choisir le pack qui correspond le mieux à mes besoins ?',
+    a: 'Nous analysons vos objectifs, votre budget et votre activité afin de recommander la formule la plus pertinente pour atteindre vos résultats rapidement.',
+  },
+  {
+    q: 'Les tarifs indiqués sont-ils fixes ou peuvent-ils varier ?',
+    a: 'Les tarifs sont fixes par pack. En cas de besoin spécifique (fonctionnalités sur mesure, intégrations complexes), un devis personnalisé peut être proposé.',
+  },
+  {
+    q: 'Proposez-vous une mise en ligne ou une livraison express ?',
+    a: 'Oui. L’option Express accélère la production et la mise en ligne — idéale pour un lancement urgent, sous réserve de disponibilité planning.',
+  },
+  {
+    q: 'Puis-je payer en plusieurs fois ?',
+    a: 'Oui, le paiement échelonné est disponible pour les packs Croissance et Sur‑mesure, sans frais cachés.',
+  },
+  {
+    q: 'Pouvez-vous personnaliser entièrement mon projet ?',
+    a: 'Absolument. Nous concevons des solutions 100 % adaptées à vos objectifs, à votre identité de marque et à vos contraintes métier.',
+  },
+  {
+    q: 'Y a‑t‑il un accompagnement après la livraison ?',
+    a: 'Oui. Nous proposons un support post‑livraison (assistance technique, correctifs, petites évolutions) et des options de maintenance.',
+  },
+  {
+    q: 'Puis-je demander des modifications après validation ?',
+    a: 'Oui. Des ajustements sont possibles selon les conditions de votre pack et la fenêtre de retours prévue au contrat.',
+  },
+  {
+    q: 'Travaillez-vous avec des particuliers ou uniquement des entreprises ?',
+    a: 'Nous accompagnons les entreprises (TPE/PME/ETI), associations et indépendants/particuliers pour leurs projets digitaux et e‑commerce.',
+  },
+  {
+    q: 'Créez-vous aussi le contenu (textes, visuels, vidéos) ?',
+    a: 'Oui. Sur demande, nous produisons des textes optimisés, des visuels et des vidéos cohérents avec votre identité et vos objectifs.',
+  },
+  {
+    q: 'Vos solutions sont‑elles compatibles mobile et tablette ?',
+    a: 'Oui. Tous nos livrables sont conçus en responsive design pour une expérience optimale sur mobile, tablette et desktop.',
+  },
+  {
+    q: 'Intervenez-vous à l’international ?',
+    a: 'Oui. Nous gérons les projets à distance et collaborons avec des clients basés partout dans le monde.',
+  },
+  {
+    q: 'Proposez-vous des formations pour utiliser les outils livrés ?',
+    a: 'Oui. Nous offrons des sessions de prise en main personnalisées (en visio ou en présentiel) pour vous rendre autonome.',
+  },
+  {
+    q: 'Avec quels outils/technologies travaillez-vous ?',
+    a: 'Nous sélectionnons des technologies modernes et fiables (stack web actuelle, CMS/Headless, intégrations API) adaptées à votre contexte.',
+  },
+  {
+    q: 'Quelles sont les étapes typiques d’un projet ?',
+    a: 'Cadrage & objectifs, conception, design, développement/intégrations, tests & QA, mise en ligne, puis support/optimisation.',
+  },
+  {
+    q: 'Quels délais prévoir pour un projet standard ?',
+    a: 'Selon le pack et la complexité : de quelques jours (Express) à plusieurs semaines. Un planning précis est fourni au démarrage.',
+  },
+  {
+    q: 'Puis-je migrer ou faire évoluer un projet existant ?',
+    a: 'Oui. Nous auditons l’existant, proposons un plan de migration/amélioration et assurons la continuité de service.',
+  },
 ];


### PR DESCRIPTION
## Summary
- enrichit le fichier de configuration FAQ avec 16 entrées détaillées
- aligne la section FAQ intégrée sur le même contenu français

## Testing
- `npm test` *(erreur : Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689aebc70eb4833181c436afb1d0d509