### PR TITLE
feat: add Calendly booking page

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -4,3 +4,6 @@ VITE_STRIPE_LINK_49=
 VITE_STRIPE_LINK_99=
 VITE_STRIPE_LINK_999=
 VITE_CAL_LINK_999=
+
+NEXT_PUBLIC_CALENDLY_URL_FR="https://calendly.com/krglobalsolutionsltd/30min"
+NEXT_PUBLIC_CALENDLY_URL_EN="https://calendly.com/krglobalsolutionsltd/30-minute-meeting-clone"

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, Suspense } from "react";
+
+const CalendlyInline = React.lazy(() => import("@/components/CalendlyInline"));
+
+export default function BookPage() {
+  useEffect(() => {
+    document.title = "Prendre rendez-vous | KR Global Solutions";
+    const meta = document.querySelector('meta[name="description"]');
+    if (meta) {
+      meta.setAttribute("content", "Réservez un créneau pour discuter de votre projet.");
+    }
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-white">
+      <main className="mx-auto max-w-5xl px-4 py-10">
+        <h1 className="text-2xl md:text-3xl font-semibold mb-3">Réserver un créneau</h1>
+        <p className="text-sm opacity-80 mb-6">
+          Choisissez l’horaire qui vous convient. Les heures s’affichent dans votre fuseau horaire.
+        </p>
+        <Suspense fallback={null}>
+          <CalendlyInline className="rounded-2xl overflow-hidden" />
+        </Suspense>
+        <p className="text-xs opacity-70 mt-4">
+          En réservant, vous acceptez nos conditions et notre politique de confidentialité.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/components/CalendlyInline.tsx
+++ b/src/components/CalendlyInline.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+type Props = { url?: string; minHeight?: number; className?: string };
+
+declare global {
+  interface Window {
+    Calendly?: { initPopupWidget: (opts: { url: string }) => void };
+  }
+}
+
+export default function CalendlyInline({ url, minHeight = 740, className }: Props) {
+  const loadedRef = useRef(false);
+
+  const resolvedUrl =
+    url ||
+    (typeof document !== "undefined" &&
+      (document.documentElement.lang?.toLowerCase().startsWith("en")
+        ? process.env.NEXT_PUBLIC_CALENDLY_URL_EN
+        : process.env.NEXT_PUBLIC_CALENDLY_URL_FR)) ||
+    process.env.NEXT_PUBLIC_CALENDLY_URL_FR;
+
+  useEffect(() => {
+    if (loadedRef.current) return;
+    loadedRef.current = true;
+    const existing = document.querySelector('script[src="https://assets.calendly.com/assets/external/widget.js"]');
+    if (!existing) {
+      const s = document.createElement("script");
+      s.src = "https://assets.calendly.com/assets/external/widget.js";
+      s.async = true;
+      document.body.appendChild(s);
+    }
+  }, []);
+
+  if (!resolvedUrl) {
+    return <div className={className}>Calendly URL manquante. Configurez NEXT_PUBLIC_CALENDLY_URL_FR / EN.</div>;
+  }
+
+  return (
+    <div
+      className={`calendly-inline-widget ${className || ""}`}
+      data-url={resolvedUrl}
+      style={{ minWidth: "320px", height: `${minHeight}px` }}
+    />
+  );
+}

--- a/src/components/CalendlyPopup.tsx
+++ b/src/components/CalendlyPopup.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+declare global {
+  interface Window {
+    Calendly?: { initPopupWidget: (opts: { url: string }) => void };
+  }
+}
+
+type PopupProps = { label?: string; url?: string; className?: string };
+
+export function CalendlyPopupButton({ label = "Book a call", url, className }: PopupProps) {
+  const resolvedUrl =
+    url ||
+    (typeof document !== "undefined" &&
+      (document.documentElement.lang?.toLowerCase().startsWith("en")
+        ? process.env.NEXT_PUBLIC_CALENDLY_URL_EN
+        : process.env.NEXT_PUBLIC_CALENDLY_URL_FR)) ||
+    process.env.NEXT_PUBLIC_CALENDLY_URL_FR;
+
+  function openCalendly() {
+    const existing = document.querySelector('script[src="https://assets.calendly.com/assets/external/widget.js"]') as HTMLScriptElement | null;
+    const open = () => {
+      if (window.Calendly && resolvedUrl) window.Calendly.initPopupWidget({ url: resolvedUrl });
+    };
+    if (!existing) {
+      const s = document.createElement("script");
+      s.src = "https://assets.calendly.com/assets/external/widget.js";
+      s.async = true;
+      s.onload = open;
+      document.body.appendChild(s);
+    } else {
+      open();
+    }
+  }
+
+  if (!resolvedUrl) return null;
+
+  return (
+    <button onClick={openCalendly} className={className || "px-4 py-2 rounded-2xl border text-sm"}>
+      {label}
+    </button>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -21,6 +21,14 @@ export function Footer() {
           >
             Mentions légales
           </a>
+          <a
+            href="/book"
+            className="underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
+          >
+            {typeof document !== 'undefined' && document.documentElement.lang?.startsWith('fr')
+              ? 'Prendre rendez-vous'
+              : 'Book a call'}
+          </a>
         </div>
         <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
           <SocialLinks variant="footer" size={22} className="justify-center sm:justify-end" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { Language, Translation } from '../data/translations';
 import KRLogoKR from "@/components/KRLogoKR";
 import { DarkZoneToggle } from './DarkZoneToggle';
 import { Menu, X } from "lucide-react";
+const CalendlyPopupButton = React.lazy(() => import("@/components/CalendlyPopup").then(m => ({ default: m.CalendlyPopupButton })));
 
 interface HeaderProps {
   currentLanguage: Language;
@@ -32,6 +33,16 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
           <DarkZoneToggle label={t.nav.darkZone} />
         </div>
         <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
+          <React.Suspense fallback={null}>
+            <CalendlyPopupButton
+              label={
+                typeof document !== 'undefined' && document.documentElement.lang?.startsWith('fr')
+                  ? 'Réserver un appel'
+                  : 'Book a call'
+              }
+              className="px-4 py-2 rounded-2xl border text-sm"
+            />
+          </React.Suspense>
           <SocialLinks variant="header" size={20} className="justify-end hidden md:flex" />
           <button
             className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,17 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import LegalPage from './app/mentions-legales/page.tsx';
+import BookPage from './app/book/page.tsx';
 import './index.css';
 
 const rootElement = document.getElementById('root')!;
 
 createRoot(rootElement).render(
   <StrictMode>
-    {window.location.pathname === '/mentions-legales' ? <LegalPage /> : <App />}
+    {window.location.pathname === '/mentions-legales'
+      ? <LegalPage />
+      : window.location.pathname === '/book'
+        ? <BookPage />
+        : <App />}
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add Calendly inline and popup components
- create booking page
- integrate booking button and link in header and footer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689af4a2a710833190cebaf6c0db3e3a