### PR TITLE
feat: add bilingual Calendly booking page

### DIFF
--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,30 +1,34 @@
-import React, { useEffect, Suspense } from "react";
+"use client";
 
-const CalendlyInline = React.lazy(() => import("@/components/CalendlyInline"));
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 
 export default function BookPage() {
+  const pathname = usePathname();
+  const isEN = pathname?.startsWith("/en");
+  const url = `${isEN ? process.env.NEXT_PUBLIC_CALENDLY_URL_EN : process.env.NEXT_PUBLIC_CALENDLY_URL_FR}?primary_color=ffffff`;
+
   useEffect(() => {
-    document.title = "Prendre rendez-vous | KR Global Solutions";
-    const meta = document.querySelector('meta[name="description"]');
-    if (meta) {
-      meta.setAttribute("content", "Réservez un créneau pour discuter de votre projet.");
-    }
+    const script = document.createElement("script");
+    script.src = "https://assets.calendly.com/assets/external/widget.js";
+    script.async = true;
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
   }, []);
 
   return (
-    <div className="min-h-screen bg-white">
-      <main className="mx-auto max-w-5xl px-4 py-10">
-        <h1 className="text-2xl md:text-3xl font-semibold mb-3">Réserver un créneau</h1>
-        <p className="text-sm opacity-80 mb-6">
-          Choisissez l’horaire qui vous convient. Les heures s’affichent dans votre fuseau horaire.
-        </p>
-        <Suspense fallback={null}>
-          <CalendlyInline className="rounded-2xl overflow-hidden" />
-        </Suspense>
-        <p className="text-xs opacity-70 mt-4">
-          En réservant, vous acceptez nos conditions et notre politique de confidentialité.
-        </p>
-      </main>
-    </div>
+    <main className="container mx-auto px-4 py-10">
+      <h1 className="text-3xl font-semibold mb-6">
+        {isEN ? "Book a slot" : "Réserver un créneau"}
+      </h1>
+
+      <div
+        className="calendly-inline-widget"
+        data-url={url}
+        style={{ minWidth: "320px", height: "800px" }}
+      />
+    </main>
   );
 }

--- a/src/components/BookCta.tsx
+++ b/src/components/BookCta.tsx
@@ -1,0 +1,15 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function BookCta() {
+  const pathname = usePathname();
+  const prefix = pathname?.startsWith("/en") ? "/en" : "";
+  const isEN = prefix === "/en";
+  
+  return (
+    <Link href={`${prefix}/book`} className="btn btn-primary">
+      {isEN ? "Book a call" : "Réserver un RDV"}
+    </Link>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,32 @@
+"use client";
 import React from 'react';
 import SocialLinks from '@/components/SocialLinks';
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 export function Footer() {
+  const pathname = usePathname();
+  const prefix = pathname?.startsWith("/en") ? "/en" : "";
+  const isEN = prefix === "/en";
+
+  const links = [
+    { label: isEN ? "Book a call" : "Prendre rendez-vous", href: `${prefix}/book` },
+    { label: "Contacts", href: "/contact" },
+    { label: "Global Solutions", href: "/" },
+    { label: "Mentions légales", href: `${prefix}/mentions-legales` },
+  ];
+
   return (
     <footer id="site-footer" className="bg-black text-white py-6">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 grid grid-cols-1 sm:grid-cols-2 gap-4 items-start text-sm">
         <div className="flex flex-col gap-2 w-full min-w-0">
+          <ul>
+            {links.map((link, i) => (
+              <li key={i}>
+                <Link href={link.href}>{link.label}</Link>
+              </li>
+            ))}
+          </ul>
           <p className="break-words truncate">
             <a
               href="mailto:contact@krglobalsolutionsltd.com"
@@ -15,20 +36,6 @@ export function Footer() {
               contact@krglobalsolutionsltd.com
             </a>
           </p>
-          <a
-            href="/mentions-legales"
-            className="underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
-          >
-            Mentions légales
-          </a>
-          <a
-            href="/book"
-            className="underline underline-offset-4 hover:no-underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white/20 rounded"
-          >
-            {typeof document !== 'undefined' && document.documentElement.lang?.startsWith('fr')
-              ? 'Prendre rendez-vous'
-              : 'Book a call'}
-          </a>
         </div>
         <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
           <SocialLinks variant="footer" size={22} className="justify-center sm:justify-end" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { Translation } from '../data/translations';
 import KRLogoKR from "@/components/KRLogoKR";
 import { DarkZoneToggle } from './DarkZoneToggle';
 import { Menu, X } from "lucide-react";
-const CalendlyPopupButton = React.lazy(() => import("@/components/CalendlyPopup").then(m => ({ default: m.CalendlyPopupButton })));
+import BookCta from "@/components/BookCta";
 
 interface HeaderProps {
   t: Translation;
@@ -27,16 +27,7 @@ export function Header({ t }: HeaderProps) {
           <DarkZoneToggle label={t.nav.darkZone} />
         </div>
         <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
-          <React.Suspense fallback={null}>
-            <CalendlyPopupButton
-              label={
-                typeof document !== 'undefined' && document.documentElement.lang?.startsWith('fr')
-                  ? 'Réserver un appel'
-                  : 'Book a call'
-              }
-              className="px-4 py-2 rounded-2xl border text-sm"
-            />
-          </React.Suspense>
+          <BookCta />
           <SocialLinks variant="header" size={20} className="justify-end hidden md:flex" />
           <button
             className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50"

--- a/src/components/pricing/PricingSection.tsx
+++ b/src/components/pricing/PricingSection.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { CALENDAR_URL, WHATSAPP_NUMBER, WHATSAPP_MSG_DEFAULT } from "@/lib/siteConfig";
+import { WHATSAPP_NUMBER, WHATSAPP_MSG_DEFAULT } from "@/lib/siteConfig";
+import BookCta from "@/components/BookCta";
 
 type Feature = { label: string };
 type Plan = {
@@ -276,14 +277,7 @@ export default function PricingSection() {
 
         {/* Double CTA global : Calendrier + WhatsApp */}
         <div className="mt-8 flex justify-center gap-3">
-          <a
-            href={CALENDAR_URL}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex h-10 items-center justify-center rounded-xl border border-white/20 bg-white/5 px-4 text-sm font-medium text-gray-200 hover:bg-white hover:text-black"
-          >
-            Réserver un RDV
-          </a>
+          <BookCta />
           <a
             href={wa("Bonjour KR Global, je souhaite un devis express via WhatsApp.")}
             target="_blank"

--- a/src/lib/siteConfig.ts
+++ b/src/lib/siteConfig.ts
@@ -2,4 +2,3 @@ export const WHATSAPP_NUMBER = "+212600000000"; // <-- REMPLACE par le numéro d
 export const WHATSAPP_MSG_DEFAULT =
   "Bonjour KR Global, je souhaite un devis rapide pour vos packs.";
 
-export const CALENDAR_URL = "https://calendly.com/ton-lien/rdv-30min"; // <-- REMPLACE par ton lien Calendly (ou autre)


### PR DESCRIPTION
## Summary
- add bilingual Calendly booking page using env URLs
- reuse BookCta component for booking links and update header, pricing and footer
- clean up site config and reorder footer links

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689af96bbbbc83319bb8d7d96613eec8