### PR TITLE
Add dark pricing section with pack cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Header } from './components/Header';
 import { HeroSection } from './components/HeroSection';
 import { AboutSection } from './components/AboutSection';
 import { Footer } from './components/Footer';
+import PricingSection from './components/PricingSection';
 import CategoriesGrid from '@/components/Pricing/CategoriesGrid';
 import FAQAccordion from '@/components/FAQ/FAQAccordion';
 import { ENABLE_DZ_PARTICLES, SHOW_PRICING } from './featureFlags';
@@ -40,6 +41,7 @@ function App() {
       
       <main>
         <HeroSection t={t} />
+        {SHOW_PRICING && <PricingSection />}
         <AboutSection t={t} isRTL={isRTL} />
         {SHOW_PRICING && (
           <>

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -1,0 +1,74 @@
+import { PackCard } from "./pricing/PackCard";
+
+export default function PricingSection() {
+  return (
+    <section className="mt-8 md:mt-12 bg-neutral-950 text-white">
+      <div className="mx-auto max-w-screen-lg px-4 sm:px-6 py-8 md:py-12">
+        <h2 className="text-3xl font-extrabold">Offres &amp; Prestations</h2>
+        <p className="mt-2 text-white/70">
+          Choisissez un pack selon votre objectif. Les tarifs sont “à partir de” et ajustés selon votre contexte.
+        </p>
+
+        <div className="mt-6 grid grid-cols-1 gap-5">
+          <PackCard
+            title="Pack Découverte"
+            subtitle="Lancez-vous dès aujourd’hui"
+            price="à partir de 49€"
+            badges={[{label:"Rapide"},{label:"Basique"},{label:"Prise en main"}]}
+            items={[
+              {label:"Visuel unique (logo simple / bannière / 3 posts)"},
+              {label:"Landing 1 section (Héros + CTA + formulaire)"},
+              {label:"Mini-workflow (Form → Email)"},
+              {label:"Montage vidéo ≤45s ou 10 retouches photo"},
+              {label:"Visio 30 min + notes d’actions"},
+              {label:"FAQ IA basique (widget 20 Q/R)"},
+            ]}
+            ctas={[
+              {label:"Je commence aujourd’hui", href:"#", variant:"primary"},
+              {label:"WhatsApp", href:"https://wa.me/", variant:"outline"},
+            ]}
+          />
+
+          <PackCard
+            title="Pack Croissance"
+            subtitle="Passez à la vitesse supérieure"
+            price="à partir de 249€"
+            badges={[{label:"Site"},{label:"Social"},{label:"IA"}]}
+            items={[
+              {label:"Mini-site 3 sections (SEO base + analytics)"},
+              {label:"15 posts + 1 micro‑vidéo (calendrier Notion)"},
+              {label:"Workflow utile (Form → Sheets + email + notif)"},
+              {label:"Vidéo ≤90s ou 20 retouches (cut + transitions)"},
+              {label:"Audit express + plan 30/60/90 (visio 45 min)"},
+              {label:"Chatbot FAQ IA (50 Q/R + capture email)"},
+            ]}
+            ctas={[
+              {label:"Réserver ce pack", href:"#", variant:"outline"},
+              {label:"WhatsApp", href:"https://wa.me/", variant:"outline"},
+            ]}
+          />
+
+          <PackCard
+            title="Pack Sur‑mesure"
+            subtitle="Votre projet clé en main"
+            price="à partir de 799€"
+            badges={[{label:"Intégrations"},{label:"IA avancée"},{label:"Automations"}]}
+            items={[
+              {label:"Site 5–7 sections / Petite boutique (Stripe + 2 automatisations)"},
+              {label:"Gestion réseaux 1 mois (30 posts, 4 reels, 1 ads)"},
+              {label:"Ops simple (x3 workflows) + dashboard Notion/Sheets"},
+              {label:"Agent IA avancé (RAG + multi‑langues)"},
+              {label:"Accompagnement 1 mois (4 visios, roadmap Notion)"},
+              {label:"Setup express (checklists + modèles + banques)"},
+            ]}
+            ctas={[
+              {label:"Obtenir mon devis gratuit", href:"#", variant:"outline"},
+              {label:"WhatsApp", href:"https://wa.me/", variant:"outline"},
+            ]}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/components/pricing/PackCard.tsx
+++ b/src/components/pricing/PackCard.tsx
@@ -1,0 +1,41 @@
+type Badge = { label: string };
+type Item = { label: string };
+type CTA = { label: string; href: string; variant?: "primary" | "outline" };
+
+export function PackCard({
+  title, subtitle, price, badges = [], items = [], ctas = [],
+}: {
+  title: string; subtitle: string; price: string;
+  badges?: Badge[]; items?: Item[]; ctas?: CTA[];
+}) {
+  return (
+    <div className="rounded-3xl bg-neutral-900 text-white p-5 border border-white/10 shadow-lg">
+      <div className="flex items-center gap-2 mb-3">
+        {badges.map((b, i) => (
+          <span key={i} className="inline-flex text-xs px-2 py-1 rounded-full bg-white/10">{b.label}</span>
+        ))}
+      </div>
+      <h3 className="text-xl font-bold">{title}</h3>
+      <p className="text-sm text-white/70">{subtitle}</p>
+      <p className="mt-3 text-3xl font-extrabold">{price}</p>
+      <ul className="mt-3 space-y-2 text-sm">
+        {items.map((it, i) => (
+          <li key={i} className="flex gap-2"><span>•</span><span>{it.label}</span></li>
+        ))}
+      </ul>
+      <div className="mt-5 flex gap-3 flex-wrap">
+        {ctas.map((c, i) => (
+          <a key={i} href={c.href}
+             className={
+               c.variant === "outline"
+                 ? "rounded-xl border border-white/30 px-4 py-2 text-sm hover:bg-white/10"
+                 : "rounded-xl bg-white text-neutral-900 px-4 py-2 text-sm font-semibold hover:bg-white/90"
+             }>
+            {c.label}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable `PackCard` component for pricing displays
- create `PricingSection` with Découverte, Croissance, and Sur-mesure packs
- render new pricing section after the hero when pricing is enabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689b178c415483319a8dd0a22c7a6eee