### PR TITLE
feat: add budget section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,8 @@ import { Header } from './components/Header';
 import { HeroSection } from './components/HeroSection';
 import { AboutSection } from './components/AboutSection';
 import { Footer } from './components/Footer';
-import CategoriesGrid from '@/components/Pricing/CategoriesGrid';
+import PricingSection from '@/components/pricing/PricingSection';
+import BudgetSection from '@/components/BudgetSection';
 import FAQAccordion from '@/components/FAQ/FAQAccordion';
 import { ENABLE_DZ_PARTICLES, SHOW_PRICING } from './featureFlags';
 
@@ -43,7 +44,8 @@ function App() {
         <AboutSection t={t} isRTL={isRTL} />
         {SHOW_PRICING && (
           <>
-            <CategoriesGrid />
+            <PricingSection />
+            <BudgetSection />
             <FAQAccordion />
           </>
         )}

--- a/src/components/BudgetSection.tsx
+++ b/src/components/BudgetSection.tsx
@@ -1,0 +1,15 @@
+export default function BudgetSection() {
+  return (
+    <section className="mx-auto max-w-screen-lg px-4 sm:px-6 py-8">
+      <h3 className="text-2xl font-extrabold text-center">Quel pack est fait pour vous ?</h3>
+      <p className="text-center text-neutral-600 dark:text-neutral-300 mt-1">Quel est votre budget ?</p>
+      <div className="mt-4 grid gap-3">
+        {["≤100€","100€-400€",">400€"].map((label) => (
+          <button key={label} className="w-full rounded-2xl border border-black/10 dark:border-white/10 py-3 text-sm font-medium hover:bg-black/5 dark:hover:bg-white/5">
+            {label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add budget section with three budget options
- display budget section after pricing section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "next/link")*

------
https://chatgpt.com/codex/tasks/task_b_689b179f47a08331bcf938987a300bb5