### PR TITLE
feat: add offers and services section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Footer } from './components/Footer';
 import PricingSection from './components/PricingSection';
 import CategoriesGrid from '@/components/Pricing/CategoriesGrid';
 import FAQSection from '@/components/FAQSection';
+import PricingCards from '@/components/pricing/PricingCards';
 import { ENABLE_DZ_PARTICLES, SHOW_PRICING } from './featureFlags';
 
 const DarkZoneParticles = React.lazy(() => import('./components/DarkZoneParticles'));
@@ -42,6 +43,7 @@ function App() {
       <main>
         <HeroSection t={t} />
         {SHOW_PRICING && <PricingSection />}
+        <PricingCards locale={currentLanguage} />
         <AboutSection t={t} isRTL={isRTL} />
         {SHOW_PRICING && (
           <>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -28,6 +28,9 @@ export function Footer() {
               </li>
             ))}
           </ul>
+          <p className="text-sm">
+            Contact : <a href="mailto:karim@karimhammouche.com" className="underline">karim@karimhammouche.com</a>
+          </p>
         </div>
         <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
           <SocialLinks variant="footer" size={22} className="justify-center sm:justify-end" />

--- a/src/components/pricing/PricingCards.tsx
+++ b/src/components/pricing/PricingCards.tsx
@@ -1,0 +1,91 @@
+"use client";
+import React from "react";
+import { packsFR, packsEN, Pack } from "@/data/packs";
+
+type Props = { locale?: "fr" | "en"; className?: string };
+
+const Badge = ({ children }: { children: React.ReactNode }) => (
+  <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium leading-none">
+    {children}
+  </span>
+);
+
+const Card = ({ pack }: { pack: Pack }) => (
+  <article className="rounded-2xl border shadow-sm p-5 md:p-6 bg-white/60 dark:bg-zinc-900/60 backdrop-blur">
+    <header className="mb-4">
+      <div className="flex flex-wrap gap-2 mb-3" aria-label="badges">
+        {pack.badges.map((b, i) => <Badge key={i}>{b}</Badge>)}
+      </div>
+      <h3 className="text-xl md:text-2xl font-semibold">{pack.title}</h3>
+      {pack.subtitle && <p className="text-sm opacity-80 mt-1">{pack.subtitle}</p>}
+      <p className="text-2xl md:text-3xl font-bold mt-3">{pack.priceFrom}</p>
+      {pack.installment && <p className="text-sm opacity-75">{pack.installment}</p>}
+    </header>
+
+    <ul className="space-y-2 text-sm md:text-base">
+      {pack.features.map((f, i) => (
+        <li key={i} className="flex gap-2">
+          <span aria-hidden>•</span>
+          <span>{f}</span>
+        </li>
+      ))}
+    </ul>
+
+    {pack.footerLinks && (
+      <div className="mt-3 space-x-3">
+        {pack.footerLinks.map((l, i) => (
+          <a key={i} href={l.href} className="underline text-sm">{l.label}</a>
+        ))}
+      </div>
+    )}
+
+    <div className="mt-5 flex flex-col sm:flex-row gap-3">
+      {pack.ctas.map((c, i) => (
+        <a
+          key={i}
+          href={c.href}
+          className={[
+            "inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring",
+            c.variant === "primary"
+              ? "bg-black text-white hover:opacity-90 dark:bg-white dark:text-black"
+              : "border hover:bg-black/5 dark:hover:bg-white/10"
+          ].join(" ")}
+        >
+          {c.label}
+        </a>
+      ))}
+    </div>
+  </article>
+);
+
+export default function PricingCards({ locale = "fr", className }: Props) {
+  const data = locale === "en" ? packsEN : packsFR;
+  return (
+    <section aria-labelledby="pricing-title" className={["w-full", className].filter(Boolean).join(" ")}>
+      <div className="max-w-6xl mx-auto px-4 md:px-6">
+        <header className="mb-6 md:mb-8">
+          <h2 id="pricing-title" className="text-3xl md:text-4xl font-extrabold">
+            {locale === "en" ? "Offers & Services" : "Offres & Prestations"}
+          </h2>
+          <p className="mt-2 text-sm md:text-base opacity-80">
+            {locale === "en"
+              ? "Choose a pack for your objective. Prices are 'from' and adjusted to your context."
+              : "Choisissez un pack selon votre objectif. Les tarifs sont “à partir de” et ajustés selon votre contexte."}
+          </p>
+          <div className="mt-4">
+            <a
+              href="#quiz-budget"
+              className="inline-flex items-center justify-center rounded-xl border px-4 py-2 text-sm hover:bg-black/5 dark:hover:bg-white/10"
+            >
+              {locale === "en" ? "Which pack fits you?" : "Quel pack est fait pour vous ?"}
+            </a>
+          </div>
+        </header>
+
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {data.map((p) => <Card key={p.id} pack={p} />)}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/data/packs.ts
+++ b/src/data/packs.ts
@@ -1,0 +1,150 @@
+export type CTA = { label: string; href: string; variant?: "primary"|"outline" };
+export type Link = { label: string; href: string };
+
+export type Pack = {
+  id: "decouverte" | "croissance" | "surmesure";
+  badges: string[];
+  title: string;
+  subtitle?: string;
+  priceFrom: string;
+  installment?: string;
+  features: string[];
+  ctas: CTA[];
+  footerLinks?: Link[];
+};
+
+export const packsFR: Pack[] = [
+  {
+    id: "decouverte",
+    badges: ["Rapide", "Basique", "Prise en main"],
+    title: "Pack Découverte",
+    subtitle: "Lancez-vous dès aujourd’hui",
+    priceFrom: "à partir de 49€",
+    features: [
+      "Visuel unique (logo simple / bannière / 3 posts)",
+      "Landing 1 section (Héros + CTA + formulaire)",
+      "Mini-workflow (Form → Email)",
+      "Montage vidéo ≤45s ou 10 retouches photo",
+      "Visio 30 min + notes d’actions",
+      "FAQ IA basique (widget 20 Q/R)"
+    ],
+    ctas: [
+      { label: "Je commence aujourd’hui", href: "#contact", variant: "primary" },
+      { label: "WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+    ],
+    footerLinks: [{ label: "Voir tout le contenu", href: "#pack-decouverte" }]
+  },
+  {
+    id: "croissance",
+    badges: ["Site", "Social", "IA"],
+    title: "Pack Croissance",
+    subtitle: "Passez à la vitesse supérieure",
+    priceFrom: "à partir de 249€",
+    installment: "ou 3× 89€/mois",
+    features: [
+      "Mini-site 3 sections (SEO base + analytics)",
+      "15 posts + 1 micro-vidéo (calendrier Notion)",
+      "Workflow utile (Form → Sheets + email + notif)",
+      "Vidéo ≤90s ou 20 retouches (cut + transitions)",
+      "Audit express + plan 30/60/90 (visio 45 min)",
+      "Chatbot FAQ IA (50 Q/R + capture email)"
+    ],
+    ctas: [
+      { label: "Réserver ce pack", href: "#contact", variant: "primary" },
+      { label: "WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+    ],
+    footerLinks: [{ label: "Voir tout le contenu", href: "#pack-croissance" }]
+  },
+  {
+    id: "surmesure",
+    badges: ["Intégrations", "IA avancée", "Automations"],
+    title: "Pack Sur-mesure",
+    subtitle: "Votre projet clé en main",
+    priceFrom: "à partir de 799€",
+    installment: "ou 3× 270€/mois",
+    features: [
+      "Site 5–7 sections / Petite boutique (Stripe + 2 automatisations)",
+      "Gestion réseaux 1 mois (30 posts, 4 reels, 1 ads)",
+      "Ops simple (x3 workflows) + dashboard Notion/Sheets",
+      "Agent IA avancé (RAG + multi-langues)",
+      "Accompagnement 1 mois (4 visios, roadmap Notion)",
+      "Setup express (checklists + modèles + banques)"
+    ],
+    ctas: [
+      { label: "Obtenir mon devis gratuit", href: "#devis", variant: "primary" },
+      { label: "Écrire sur WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+    ],
+    footerLinks: [
+      { label: "Réserver un RDV", href: "#rdv" },
+      { label: "Voir tout le contenu", href: "#pack-surmesure" }
+    ]
+  }
+];
+
+export const packsEN: Pack[] = [
+  {
+    id: "decouverte",
+    badges: ["Fast", "Basic", "Onboarding"],
+    title: "Starter Pack",
+    subtitle: "Launch today",
+    priceFrom: "from €49",
+    features: [
+      "Single visual (simple logo / banner / 3 posts)",
+      "One-section landing (Hero + CTA + form)",
+      "Mini-workflow (Form → Email)",
+      "Video edit ≤45s or 10 photo touch-ups",
+      "30-min call + action notes",
+      "Basic AI FAQ (20 Q&A widget)"
+    ],
+    ctas: [
+      { label: "Start now", href: "#contact", variant: "primary" },
+      { label: "WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+    ],
+    footerLinks: [{ label: "See all details", href: "#pack-decouverte" }]
+  },
+  {
+    id: "croissance",
+    badges: ["Website", "Social", "AI"],
+    title: "Growth Pack",
+    subtitle: "Shift up a gear",
+    priceFrom: "from €249",
+    installment: "or 3× €89/mo",
+    features: [
+      "3-section mini-site (base SEO + analytics)",
+      "15 posts + 1 micro-video (Notion calendar)",
+      "Useful workflow (Form → Sheets + email + notif)",
+      "Video ≤90s or 20 edits (cuts + transitions)",
+      "Express audit + 30/60/90 plan (45‑min call)",
+      "AI FAQ chatbot (50 Q&A + email capture)"
+    ],
+    ctas: [
+      { label: "Book this pack", href: "#contact", variant: "primary" },
+      { label: "WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+    ],
+    footerLinks: [{ label: "See all details", href: "#pack-croissance" }]
+  },
+  {
+    id: "surmesure",
+    badges: ["Integrations", "Advanced AI", "Automations"],
+    title: "Custom Pack",
+    subtitle: "Your turnkey project",
+    priceFrom: "from €799",
+    installment: "or 3× €270/mo",
+    features: [
+      "5–7 section site / Small shop (Stripe + 2 automations)",
+      "1‑month social management (30 posts, 4 reels, 1 ad)",
+      "Simple ops (x3 workflows) + Notion/Sheets dashboard",
+      "Advanced AI agent (RAG + multilingual)",
+      "1‑month guidance (4 calls, Notion roadmap)",
+      "Express setup (checklists + templates + banks)"
+    ],
+    ctas: [
+      { label: "Get my free quote", href: "#devis", variant: "primary" },
+      { label: "Message on WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+    ],
+    footerLinks: [
+      { label: "Book a meeting", href: "#rdv" },
+      { label: "See all details", href: "#pack-surmesure" }
+    ]
+  }
+];


### PR DESCRIPTION
## Summary
- add packs data with FR/EN content
- create responsive PricingCards component
- integrate offers section on home page and add contact email in footer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b289404588331b39a3159cb42bde5