### PR TITLE
feat: add bilingual FAQ accordion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,11 @@ import { AboutSection } from './components/AboutSection';
 import { Footer } from './components/Footer';
 import PricingSection from './components/PricingSection';
 import CategoriesGrid from '@/components/Pricing/CategoriesGrid';
-import FAQSection from '@/components/FAQSection';
 import PricingCards from '@/components/pricing/PricingCards';
 import { ENABLE_DZ_PARTICLES, SHOW_PRICING } from './featureFlags';
 
 const DarkZoneParticles = React.lazy(() => import('./components/DarkZoneParticles'));
+const FAQAccordion = React.lazy(() => import('@/components/faq/FAQAccordion'));
 
 function App() {
   const { currentLanguage, changeLanguage, t, isRTL } = useLanguage();
@@ -48,7 +48,9 @@ function App() {
         {SHOW_PRICING && (
           <>
             <CategoriesGrid />
-            <FAQSection />
+            <React.Suspense fallback={null}>
+              <FAQAccordion locale={currentLanguage} />
+            </React.Suspense>
           </>
         )}
       </main>

--- a/src/components/faq/FAQAccordion.tsx
+++ b/src/components/faq/FAQAccordion.tsx
@@ -1,0 +1,41 @@
+"use client";
+import React from "react";
+import { faqFR, faqEN, QA } from "@/data/faq";
+
+type Props = { locale?: "fr" | "en"; className?: string };
+
+function Item({ qa, idx }: { qa: QA; idx: number }) {
+  const id = `faq-${idx}`;
+  return (
+    <details className="rounded-2xl border bg-white/60 dark:bg-zinc-900/60 p-4 md:p-5">
+      <summary
+        className="cursor-pointer list-none select-none flex items-center justify-between gap-3 text-base md:text-lg font-medium"
+        aria-controls={`${id}-panel`}
+        aria-expanded="false"
+      >
+        <span>{qa.q}</span>
+        <span aria-hidden className="inline-flex h-7 w-7 items-center justify-center rounded-full border">+</span>
+      </summary>
+      <div id={`${id}-panel`} className="pt-3 text-sm md:text-base opacity-90">
+        {qa.a}
+      </div>
+    </details>
+  );
+}
+
+export default function FAQAccordion({ locale = "fr", className }: Props) {
+  const data = locale === "en" ? faqEN : faqFR;
+  return (
+    <section id="faq" aria-labelledby="faq-title" className={["w-full", className].filter(Boolean).join(" ")}>
+      <div className="max-w-6xl mx-auto px-4 md:px-6">
+        <header className="mb-5 md:mb-7">
+          <h2 id="faq-title" className="text-3xl md:text-4xl font-extrabold">FAQ</h2>
+        </header>
+        <div className="space-y-3 md:space-y-4">
+          {data.map((qa, i) => <Item key={i} qa={qa} idx={i} />)}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -1,0 +1,136 @@
+export type QA = { q: string; a: string };
+
+export const faqFR: QA[] = [
+  {
+    q: "Comment choisir le pack qui correspond le mieux à mes besoins ?",
+    a: "Partez de votre objectif principal (visibilité rapide, croissance, clé en main). Le pack Découverte convient pour un démarrage rapide, Croissance pour un mini‑site + social + automatisations utiles, Sur‑mesure pour un projet complet (site 5–7 sections, boutique Stripe, IA avancée). Si besoin, nous pouvons ajuster le contenu de chaque pack."
+  },
+  {
+    q: "Les tarifs indiqués sont-ils fixes ou peuvent-ils varier ?",
+    a: "Ce sont des tarifs “à partir de”. Ils sont ajustés selon la complexité de votre projet (scope, intégrations, délais). Un devis précis est fourni avant démarrage."
+  },
+  {
+    q: "Proposez-vous une mise en ligne ou une livraison express ?",
+    a: "Oui, une option express est possible selon la charge et le périmètre. Indiquez votre deadline lors de la prise de contact."
+  },
+  {
+    q: "Puis-je payer en plusieurs fois ?",
+    a: "Oui, des paiements échelonnés sont possibles sur certains packs (ex. 3×). Les modalités exactes sont confirmées dans le devis."
+  },
+  {
+    q: "Pouvez-vous personnaliser entièrement mon projet ?",
+    a: "Oui. Le pack Sur‑mesure est prévu pour une personnalisation complète (branding, pages, intégrations, automatisations, IA)."
+  },
+  {
+    q: "Y a-t-il un accompagnement après la livraison ?",
+    a: "Oui, un accompagnement d’un mois est inclus dans le pack Sur‑mesure. Pour les autres packs, des options de support peuvent être ajoutées."
+  },
+  {
+    q: "Puis-je demander des modifications après validation ?",
+    a: "Oui, des révisions sont prévues pendant la phase de livraison. Après validation finale, un nouveau devis peut être établi si le scope change."
+  },
+  {
+    q: "Travaillez-vous avec des particuliers ou uniquement des entreprises ?",
+    a: "Nous travaillons principalement avec des entreprises et des indépendants, mais des profils particuliers peuvent être étudiés."
+  },
+  {
+    q: "Créez-vous aussi le contenu (textes, visuels, vidéos) ?",
+    a: "Oui, selon le pack. Découverte inclut un visuel simple ; Croissance inclut 15 posts + 1 micro‑vidéo ; Sur‑mesure inclut une gestion réseaux d’un mois. Des options supplémentaires sont possibles."
+  },
+  {
+    q: "Vos solutions sont-elles compatibles mobile et tablette ?",
+    a: "Oui. Tous les livrables sont conçus en responsive (mobile, tablette, desktop)."
+  },
+  {
+    q: "Intervenez-vous à l’international ?",
+    a: "Oui. Les prestations peuvent être réalisées à distance pour des clients internationaux."
+  },
+  {
+    q: "Proposez-vous des formations pour utiliser les outils livrés ?",
+    a: "Oui. Une prise en main est incluse dans certains packs et peut être étendue (sessions, vidéos, documentation)."
+  },
+  {
+    q: "Avec quels outils/technologies travaillez-vous ?",
+    a: "Principalement Next.js, React, TypeScript, Tailwind, Framer Motion, intégrations Stripe, Notion/Sheets, et agents IA (RAG)."
+  },
+  {
+    q: "Quelles sont les étapes typiques d’un projet ?",
+    a: "Brief et devis → kick‑off → design/contenus → développement/intégrations → tests/SEO/accessibilité → mise en ligne → accompagnement."
+  },
+  {
+    q: "Quels délais prévoir pour un projet standard ?",
+    a: "Selon le pack et votre disponibilité (contenus, validations). Découverte: rapide ; Croissance: court ; Sur‑mesure: variable. Une timeline est fournie au kick‑off."
+  },
+  {
+    q: "Puis-je migrer ou faire évoluer un projet existant ?",
+    a: "Oui. Audit + plan d’action, puis migration ou refonte progressive selon vos priorités et contraintes."
+  }
+];
+
+export const faqEN: QA[] = [
+  {
+    q: "How do I choose the best pack for my needs?",
+    a: "Start from your main goal (quick visibility, growth, turnkey). Starter is for fast launch, Growth for a mini‑site + social + useful automations, Custom for a complete project (5–7‑section site, Stripe shop, advanced AI). We can adjust each pack if needed."
+  },
+  {
+    q: "Are the listed prices fixed or can they vary?",
+    a: "They are “from” prices. Final pricing depends on scope, integrations and deadlines. A precise quote is provided before kickoff."
+  },
+  {
+    q: "Do you offer express go‑live or expedited delivery?",
+    a: "Yes, express delivery is possible depending on workload and scope. Share your deadline during contact."
+  },
+  {
+    q: "Can I pay in installments?",
+    a: "Yes, staged payments (e.g., 3×) are available on some packs. Exact terms are confirmed in the quote."
+  },
+  {
+    q: "Can you fully customize my project?",
+    a: "Yes. The Custom pack is designed for full customization (branding, pages, integrations, automations, AI)."
+  },
+  {
+    q: "Is there post‑delivery support?",
+    a: "Yes, one month of guidance is included in the Custom pack. Other packs can add support options."
+  },
+  {
+    q: "Can I request changes after approval?",
+    a: "Yes, revisions are planned during delivery. After final approval, scope changes may require a new quote."
+  },
+  {
+    q: "Do you work with individuals or only businesses?",
+    a: "We mainly work with businesses and independents, but individual cases can be considered."
+  },
+  {
+    q: "Do you also create content (copy, visuals, videos)?",
+    a: "Yes, depending on the pack. Starter includes a simple visual; Growth includes 15 posts + 1 micro‑video; Custom includes one‑month social management. Add‑ons are possible."
+  },
+  {
+    q: "Are your solutions mobile and tablet friendly?",
+    a: "Yes. All deliverables are built responsive (mobile, tablet, desktop)."
+  },
+  {
+    q: "Do you work internationally?",
+    a: "Yes. All services can be delivered remotely for international clients."
+  },
+  {
+    q: "Do you provide training to use the delivered tools?",
+    a: "Yes. Onboarding is included in some packs and can be extended (sessions, videos, docs)."
+  },
+  {
+    q: "Which tools/technologies do you use?",
+    a: "Mainly Next.js, React, TypeScript, Tailwind, Framer Motion, Stripe integrations, Notion/Sheets, and AI agents (RAG)."
+  },
+  {
+    q: "What are the typical project steps?",
+    a: "Brief & quote → kickoff → design/content → development/integrations → tests/SEO/accessibility → go‑live → guidance."
+  },
+  {
+    q: "What timelines should I expect for a standard project?",
+    a: "Depends on the pack and your availability (content, approvals). Starter: fast; Growth: short; Custom: variable. A timeline is provided at kickoff."
+  },
+  {
+    q: "Can you migrate or improve an existing project?",
+    a: "Yes. We start with an audit + action plan, then migrate or progressively revamp based on priorities and constraints."
+  }
+];
+


### PR DESCRIPTION
## Summary
- add FR/EN FAQ data source
- implement accessible FAQ accordion with details/summary
- integrate FAQ section in app using lazy loading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689b2a472e5483318a8f6a6471d8e144