### PR TITLE
refactor: remove next/dynamic usage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { motion } from 'framer-motion';
 import { useLanguage } from './hooks/useLanguage';
 import { Header } from './components/Header';
@@ -9,11 +9,10 @@ import PricingSection from './components/PricingSection';
 import CategoriesGrid from '@/components/Pricing/CategoriesGrid';
 import PricingCards from '@/components/pricing/PricingCards';
 import { ENABLE_DZ_PARTICLES, SHOW_PRICING } from './featureFlags';
-import dynamic from "next/dynamic";
 
 const DarkZoneParticles = React.lazy(() => import('./components/DarkZoneParticles'));
 // FAQ
-const FAQAccordion = dynamic(() => import('@/components/faq/FAQAccordion'), { ssr: false });
+const FAQAccordion = React.lazy(() => import('@/components/faq/FAQAccordion'));
 
 function App() {
   const { currentLanguage, changeLanguage, t, isRTL } = useLanguage();
@@ -51,16 +50,18 @@ function App() {
           <>
             <CategoriesGrid />
             {/* FAQ */}
-            <FAQAccordion locale="fr" />
+            <Suspense fallback={null}>
+              <FAQAccordion locale="fr" />
+            </Suspense>
           </>
         )}
       </main>
 
       <Footer />
       {ENABLE_DZ_PARTICLES && showParticles && (
-        <React.Suspense fallback={null}>
+        <Suspense fallback={null}>
           <DarkZoneParticles />
-        </React.Suspense>
+        </Suspense>
       )}
     </motion.div>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,10 @@
 {
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import * as path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -10,7 +10,12 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      external: [], // S'assurer que 'next/dynamic' n'est PAS listé ici
     },
   },
 });


### PR DESCRIPTION
## Summary
- replace `next/dynamic` with React.lazy and Suspense for FAQ
- ensure Vite alias for `@` and no external next/dynamic
- add TS paths alias for editor support

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b43e119a8833184a64e64a7dbb64a