### PR TITLE
feat: update WhatsApp links and buttons

### DIFF
--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -25,7 +25,7 @@ export default function PricingSection() {
             ]}
             ctas={[
               {label:"Je commence aujourd’hui", href:"#", variant:"primary"},
-              {label:"WhatsApp", href:"https://wa.me/", variant:"outline"},
+              {label:"WhatsApp", href:"https://wa.me/33743561304", variant:"outline"},
             ]}
           />
 
@@ -44,7 +44,7 @@ export default function PricingSection() {
             ]}
             ctas={[
               {label:"Réserver ce pack", href:"#", variant:"outline"},
-              {label:"WhatsApp", href:"https://wa.me/", variant:"outline"},
+              {label:"WhatsApp", href:"https://wa.me/33743561304", variant:"outline"},
             ]}
           />
 
@@ -63,7 +63,7 @@ export default function PricingSection() {
             ]}
             ctas={[
               {label:"Obtenir mon devis gratuit", href:"#", variant:"outline"},
-              {label:"WhatsApp", href:"https://wa.me/", variant:"outline"},
+              {label:"WhatsApp", href:"https://wa.me/33743561304", variant:"outline"},
             ]}
           />
         </div>

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -1,29 +1,11 @@
 /* eslint-disable react-refresh/only-export-components */
 import React from "react";
-import { WHATSAPP_NUMBER, WHATSAPP_MSG_DEFAULT } from "@/lib/siteConfig";
 import { FaTiktok, FaInstagram, FaLinkedin, FaGithub } from "react-icons/fa";
 import { SiFiverr } from "react-icons/si";
 
 type Variant = "header" | "footer";
 
-const waHref = `https://wa.me/${WHATSAPP_NUMBER.replace(/\D/g, "")}?text=${encodeURIComponent(
-  WHATSAPP_MSG_DEFAULT
-)}`;
-
 export const socialLinks = [
-  {
-    id: "whatsapp",
-    label: "WhatsApp",
-    href: waHref,
-    icon: (size: number) => (
-      <span
-        className="flex items-center justify-center rounded-full bg-green-500 text-white font-bold"
-        style={{ width: size, height: size }}
-      >
-        W
-      </span>
-    ),
-  },
   { id: "tiktok", label: "TikTok", href: "https://www.tiktok.com/@krglobalsolutions?_t=ZS-8yl0PL5V6CQ&_r=1", icon: (size: number) => <FaTiktok size={size} /> },
   { id: "instagram", label: "Instagram", href: "https://www.instagram.com/krgloballtd?igsh=c29uN3VyNGFyb2xv&utm_source=qr", icon: (size: number) => <FaInstagram size={size} /> },
   { id: "fiverr", label: "Fiverr", href: "https://www.fiverr.com/krgloballtd/buying?source=avatar_menu_profile", icon: (size: number) => <SiFiverr size={size} /> },

--- a/src/components/pricing/PackCard.tsx
+++ b/src/components/pricing/PackCard.tsx
@@ -25,12 +25,17 @@ export function PackCard({
       </ul>
       <div className="mt-5 flex gap-3 flex-wrap">
         {ctas.map((c, i) => (
-          <a key={i} href={c.href}
-             className={
-               c.variant === "outline"
-                 ? "rounded-xl border border-white/30 px-4 py-2 text-sm hover:bg-white/10"
-                 : "rounded-xl bg-white text-neutral-900 px-4 py-2 text-sm font-semibold hover:bg-white/90"
-             }>
+          <a
+            key={i}
+            href={c.href}
+            target={c.href.includes("wa.me") ? "_blank" : undefined}
+            rel={c.href.includes("wa.me") ? "noopener noreferrer" : undefined}
+            className={
+              c.variant === "outline"
+                ? "rounded-xl border border-white/30 px-4 py-2 text-sm hover:bg-white/10"
+                : "rounded-xl bg-white text-neutral-900 px-4 py-2 text-sm font-semibold hover:bg-white/90"
+            }
+          >
             {c.label}
           </a>
         ))}

--- a/src/components/pricing/PricingCards.tsx
+++ b/src/components/pricing/PricingCards.tsx
@@ -44,6 +44,8 @@ const Card = ({ pack }: { pack: Pack }) => (
         <a
           key={i}
           href={c.href}
+          target={c.href.includes("wa.me") ? "_blank" : undefined}
+          rel={c.href.includes("wa.me") ? "noopener noreferrer" : undefined}
           className={[
             "inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring",
             c.variant === "primary"

--- a/src/components/pricing/PricingSection.tsx
+++ b/src/components/pricing/PricingSection.tsx
@@ -223,7 +223,7 @@ function Card({
         <a
           href={wa(`Bonjour KR Global, je veux avancer sur ${plan.name}.`)}
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           className="ml-2 inline-flex h-10 items-center justify-center rounded-xl border border-[#25D366]/40 px-3 text-sm font-semibold text-[#25D366] hover:bg-[#25D366] hover:text-black"
           aria-label="WhatsApp devis rapide"
         >
@@ -281,10 +281,10 @@ export default function PricingSection() {
           <a
             href={wa("Bonjour KR Global, je souhaite un devis express via WhatsApp.")}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="inline-flex h-10 items-center justify-center rounded-xl border border-[#25D366]/40 px-4 text-sm font-semibold text-[#25D366] hover:bg-[#25D366] hover:text-black"
           >
-            Écrire sur WhatsApp
+            WhatsApp
           </a>
         </div>
       </div>

--- a/src/components/pricing/QuizPack.tsx
+++ b/src/components/pricing/QuizPack.tsx
@@ -78,7 +78,7 @@ export default function QuizPack() {
             <a
               href={waHref(planLabel)}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="inline-flex h-10 items-center justify-center rounded-lg border border-[#25D366]/40 px-4 text-sm font-semibold text-[#25D366] hover:bg-[#25D366] hover:text-black"
             >
               WhatsApp

--- a/src/data/packs.ts
+++ b/src/data/packs.ts
@@ -30,7 +30,7 @@ export const packsFR: Pack[] = [
     ],
     ctas: [
       { label: "Je commence aujourd’hui", href: "#contact", variant: "primary" },
-      { label: "WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+      { label: "WhatsApp", href: "https://wa.me/33743561304", variant: "outline" }
     ],
     footerLinks: [{ label: "Voir tout le contenu", href: "#pack-decouverte" }]
   },
@@ -51,7 +51,7 @@ export const packsFR: Pack[] = [
     ],
     ctas: [
       { label: "Réserver ce pack", href: "#contact", variant: "primary" },
-      { label: "WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+      { label: "WhatsApp", href: "https://wa.me/33743561304", variant: "outline" }
     ],
     footerLinks: [{ label: "Voir tout le contenu", href: "#pack-croissance" }]
   },
@@ -72,7 +72,7 @@ export const packsFR: Pack[] = [
     ],
     ctas: [
       { label: "Obtenir mon devis gratuit", href: "#devis", variant: "primary" },
-      { label: "Écrire sur WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+      { label: "WhatsApp", href: "https://wa.me/33743561304", variant: "outline" }
     ],
     footerLinks: [
       { label: "Réserver un RDV", href: "#rdv" },
@@ -98,7 +98,7 @@ export const packsEN: Pack[] = [
     ],
     ctas: [
       { label: "Start now", href: "#contact", variant: "primary" },
-      { label: "WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+      { label: "WhatsApp", href: "https://wa.me/33743561304", variant: "outline" }
     ],
     footerLinks: [{ label: "See all details", href: "#pack-decouverte" }]
   },
@@ -119,7 +119,7 @@ export const packsEN: Pack[] = [
     ],
     ctas: [
       { label: "Book this pack", href: "#contact", variant: "primary" },
-      { label: "WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+      { label: "WhatsApp", href: "https://wa.me/33743561304", variant: "outline" }
     ],
     footerLinks: [{ label: "See all details", href: "#pack-croissance" }]
   },
@@ -140,7 +140,7 @@ export const packsEN: Pack[] = [
     ],
     ctas: [
       { label: "Get my free quote", href: "#devis", variant: "primary" },
-      { label: "Message on WhatsApp", href: "https://wa.me/<WHATSAPP_NUMBER>", variant: "outline" }
+      { label: "Message on WhatsApp", href: "https://wa.me/33743561304", variant: "outline" }
     ],
     footerLinks: [
       { label: "Book a meeting", href: "#rdv" },

--- a/src/lib/siteConfig.ts
+++ b/src/lib/siteConfig.ts
@@ -1,4 +1,4 @@
-export const WHATSAPP_NUMBER = "+212600000000"; // <-- REMPLACE par le numéro de TA bulle flottante (format international)
+export const WHATSAPP_NUMBER = "+33743561304"; // <-- REMPLACE par le numéro de TA bulle flottante (format international)
 export const WHATSAPP_MSG_DEFAULT =
   "Bonjour KR Global, je souhaite un devis rapide pour vos packs.";
 


### PR DESCRIPTION
## Summary
- link pack cards to WhatsApp number +33743561304 and open in new tab
- remove WhatsApp from header and footer social links
- rename "Écrire sur WhatsApp" to "WhatsApp"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in scripts/fix-deploy.ts)*

------
https://chatgpt.com/codex/tasks/task_b_689b46dd6f548331aeacd4b434420d17