### PR TITLE
Move About section below footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,15 +43,14 @@ function App() {
       <main>
         <HeroSection t={t} />
         {SHOW_PRICING && <PricingSection />}
-        <AboutSection t={t} isRTL={isRTL} />
         {SHOW_PRICING && <CategoriesGrid />}
         {/* ===== Section FAQ ===== */}
         <Suspense fallback={null}>
           <FAQAccordion locale="fr" />
         </Suspense>
+        <Footer />
+        <AboutSection t={t} isRTL={isRTL} />
       </main>
-
-      <Footer />
       {ENABLE_DZ_PARTICLES && showParticles && (
         <Suspense fallback={null}>
           <DarkZoneParticles />


### PR DESCRIPTION
## Summary
- place AboutSection component at bottom of the main layout after all other sections
- keep existing styling, translations and dark mode integration

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm run lint` *(fails: Unexpected any in scripts/fix-deploy.ts)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689b4e6a57908331b449f5f2a27174a1