### PR TITLE
fix: keep footer anchored to page bottom

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,18 +29,18 @@ function App() {
 
   return (
     <motion.div
-      className="min-h-screen bg-white dz-bg dz-fg"
+      className="flex min-h-screen flex-col bg-white dz-bg dz-fg"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
     >
-      <Header 
+      <Header
         currentLanguage={currentLanguage}
         onLanguageChange={changeLanguage}
         t={t}
       />
-      
-      <main>
+
+      <main className="flex-1">
         <HeroSection t={t} />
         {SHOW_PRICING && <PricingSection />}
         {SHOW_PRICING && <CategoriesGrid />}
@@ -48,9 +48,9 @@ function App() {
         <Suspense fallback={null}>
           <FAQAccordion locale="fr" />
         </Suspense>
-        <Footer />
         <AboutSection t={t} isRTL={isRTL} />
       </main>
+      <Footer />
       {ENABLE_DZ_PARTICLES && showParticles && (
         <Suspense fallback={null}>
           <DarkZoneParticles />

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,19 @@
 html,
 body {
   overflow-x: hidden;
+  height: 100%;
+  margin: 0;
+}
+
+#__next,
+#root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+main {
+  flex: 1;
 }
 
 img,


### PR DESCRIPTION
## Summary
- apply flex column layout so footer stays at page bottom
- restructure app layout moving footer outside main and letting main grow
- add global CSS to make html/body full-height and root element a flex container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src`
- `npm run build`
- `node tests/no-overflow.mjs`


------
https://chatgpt.com/codex/tasks/task_b_689b51cdef848331afea6bea2657aa6b