### PR TITLE
feat: restore offers section with i18n

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2,5 +2,47 @@
   "portfolio": {
     "karim": "Karim's Portfolio",
     "raphael": "Raphaël's Portfolio"
+  },
+  "offers": {
+    "title": "Offers & Services",
+    "subtitle": "Pick a pack for your goal. Prices are “from” and adjusted to your context.",
+    "whichPack": "Which pack is right for you?",
+    "tag": { "basique": "Basic", "populaire": "Popular", "premium": "Premium" },
+    "badge": {
+      "fast": "Fast", "basic": "Basic", "onboarding": "Onboarding",
+      "site": "Website", "social": "Social", "ai": "AI",
+      "integrations": "Integrations", "aiAdvanced": "Advanced AI", "automations": "Automations"
+    },
+    "cta": {
+      "startNow": "Start today", "bookPack": "Book this pack",
+      "quote": "Get my free quote", "bookMeeting": "Book a meeting", "whatsapp": "WhatsApp"
+    },
+    "starter": {
+      "title": "Starter Pack", "subtitle": "Get launched today",
+      "price": "from €49", "perMonth": "",
+      "b1": "One visual (simple logo / banner / 3 posts)",
+      "b2": "One-section landing (Hero + CTA + form)",
+      "b3": "Mini-workflow (Form → Email)",
+      "b4": "Video edit ≤45s or 10 photo edits",
+      "b5": "30-min call + action notes"
+    },
+    "growth": {
+      "title": "Growth Pack", "subtitle": "Shift into higher gear",
+      "price": "from €249", "perMonth": "or 3× €89/mo",
+      "b1": "Mini-site 3 sections (basic SEO + analytics)",
+      "b2": "15 posts + 1 micro-video (Notion calendar)",
+      "b3": "Useful workflow (Form → Sheets + email + notif)",
+      "b4": "Video ≤90s or 20 edits (cuts + transitions)",
+      "b5": "Express audit + 30/60/90 plan (45-min call)"
+    },
+    "custom": {
+      "title": "Custom Pack", "subtitle": "Turn-key project",
+      "price": "from €799", "perMonth": "or 3× €270/mo",
+      "b1": "5–7-section site / Small shop (Stripe + 2 automations)",
+      "b2": "1-month social mgmt (30 posts, 4 reels, 1 ad)",
+      "b3": "Simple ops (x3 workflows) + Notion/Sheets dashboard",
+      "b4": "Advanced AI agent (RAG + multi-language)",
+      "b5": "Express setup (checklists + templates + banks)"
+    }
   }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -2,5 +2,47 @@
   "portfolio": {
     "karim": "Portfolio Karim",
     "raphael": "Portfolio Raphaël"
+  },
+  "offers": {
+    "title": "Offres & Prestations",
+    "subtitle": "Choisissez un pack selon votre objectif. Les tarifs sont “à partir de” et ajustés selon votre contexte.",
+    "whichPack": "Quel pack est fait pour vous ?",
+    "tag": { "basique": "Basique", "populaire": "Populaire", "premium": "Premium" },
+    "badge": {
+      "fast": "Rapide", "basic": "Basique", "onboarding": "Prise en main",
+      "site": "Site", "social": "Social", "ai": "IA",
+      "integrations": "Intégrations", "aiAdvanced": "IA avancée", "automations": "Automations"
+    },
+    "cta": {
+      "startNow": "Je commence aujourd’hui", "bookPack": "Réserver ce pack",
+      "quote": "Obtenir mon devis gratuit", "bookMeeting": "Réserver un RDV", "whatsapp": "WhatsApp"
+    },
+    "starter": {
+      "title": "Pack Découverte", "subtitle": "Lancez-vous dès aujourd’hui",
+      "price": "à partir de 49€", "perMonth": "",
+      "b1": "Visuel unique (logo simple / bannière / 3 posts)",
+      "b2": "Landing 1 section (Héros + CTA + formulaire)",
+      "b3": "Mini-workflow (Form → Email)",
+      "b4": "Montage vidéo ≤45s ou 10 retouches photo",
+      "b5": "Visio 30 min + notes d’actions"
+    },
+    "growth": {
+      "title": "Pack Croissance", "subtitle": "Passez à la vitesse supérieure",
+      "price": "à partir de 249€", "perMonth": "ou 3× 89€/mois",
+      "b1": "Mini-site 3 sections (SEO base + analytics)",
+      "b2": "15 posts + 1 micro‑vidéo (calendrier Notion)",
+      "b3": "Workflow utile (Form → Sheets + email + notif)",
+      "b4": "Vidéo ≤90s ou 20 retouches (cut + transitions)",
+      "b5": "Audit express + plan 30/60/90 (visio 45 min)"
+    },
+    "custom": {
+      "title": "Pack Sur‑mesure", "subtitle": "Votre projet clé en main",
+      "price": "à partir de 799€", "perMonth": "ou 3× 270€/mois",
+      "b1": "Site 5–7 sections / Petite boutique (Stripe + 2 automatisations)",
+      "b2": "Gestion réseaux 1 mois (30 posts, 4 reels, 1 ads)",
+      "b3": "Ops simple (x3 workflows) + dashboard Notion/Sheets",
+      "b4": "Agent IA avancé (RAG + multi‑langues)",
+      "b5": "Setup express (checklists + modèles + banques)"
+    }
   }
 }

--- a/scripts/fix-deploy.ts
+++ b/scripts/fix-deploy.ts
@@ -5,7 +5,7 @@ function readJSON(file: string) {
   return JSON.parse(fs.readFileSync(file, 'utf-8'));
 }
 
-function writeJSON(file: string, data: any) {
+function writeJSON(file: string, data: unknown) {
   fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,8 @@ import { Header } from './components/Header';
 import { HeroSection } from './components/HeroSection';
 import { AboutSection } from './components/AboutSection';
 import { Footer } from './components/Footer';
-import PricingSection from '@/sections/Pricing';
-import CategoriesGrid from '@/components/Pricing/CategoriesGrid';
+import OffersSection from '@/components/OffersSection';
+import QuizPack from '@/components/pricing/QuizPack';
 import { ENABLE_DZ_PARTICLES, SHOW_PRICING } from './featureFlags';
 
 const DarkZoneParticles = React.lazy(() => import('./components/DarkZoneParticles'));
@@ -42,8 +42,8 @@ function App() {
 
       <main className="flex-1">
         <HeroSection t={t} />
-        {SHOW_PRICING && <PricingSection />}
-        {SHOW_PRICING && <CategoriesGrid />}
+        {SHOW_PRICING && <OffersSection />}
+        {SHOW_PRICING && <QuizPack />}
         {/* ===== Section FAQ ===== */}
         <Suspense fallback={null}>
           <FAQAccordion />

--- a/src/components/OffersSection.tsx
+++ b/src/components/OffersSection.tsx
@@ -1,0 +1,93 @@
+"use client";
+import { packs } from "@/data/packs";
+import { useMemo } from "react";
+import { useLanguage } from "@/hooks/useLanguage";
+
+function translate(obj: Record<string, unknown>, key: string): string {
+  return key.split(".").reduce<unknown>((o, k) => (o && typeof o === "object" ? (o as Record<string, unknown>)[k] : undefined), obj) as string ?? key;
+}
+
+export default function OffersSection() {
+  const { t } = useLanguage();
+  const data = useMemo(() => packs, []);
+  const tr = (key: string) => translate(t, key);
+
+  return (
+    <section id="offers" className="w-full py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4">
+        <header className="mb-8 sm:mb-12 text-center">
+          <h2 className="text-3xl sm:text-4xl font-bold">{tr("offers.title")}</h2>
+          <p className="mt-2 text-base sm:text-lg opacity-80">{tr("offers.subtitle")}</p>
+          <div className="mt-4">
+            <a href="#pack-quiz" className="inline-block rounded-2xl border px-4 py-2 text-sm">
+              {tr("offers.whichPack")}
+            </a>
+          </div>
+        </header>
+
+        <div className="grid gap-6 sm:gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+          {data.map((p) => (
+            <article
+              key={p.id}
+              className="rounded-3xl border shadow-lg p-6 sm:p-8 bg-white/60 dark:bg-neutral-900/60 backdrop-blur"
+            >
+              {p.tag && (
+                <span className="inline-flex items-center rounded-full border px-3 py-1 text-xs mb-4">
+                  {tr(`offers.tag.${p.tag.toLowerCase()}`)}
+                </span>
+              )}
+
+              <h3 className="text-2xl font-semibold">{tr(p.titleKey)}</h3>
+              <p className="mt-1 opacity-80">{tr(p.subtitleKey)}</p>
+
+              <div className="mt-4">
+                <div className="text-3xl sm:text-4xl font-extrabold">{tr(p.priceKey)}</div>
+                {p.perMonthKey && <div className="opacity-70">{tr(p.perMonthKey)}</div>}
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {p.badges.map((b) => (
+                  <span key={b} className="rounded-full border px-3 py-1 text-xs">
+                    {tr(b)}
+                  </span>
+                ))}
+              </div>
+
+              <ul className="mt-6 space-y-2">
+                {p.bullets.map((b) => (
+                  <li key={b} className="flex gap-2">
+                    <span className="mt-2 h-1.5 w-1.5 rounded-full border shrink-0" />
+                    <span>{tr(b)}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="mt-8 flex flex-wrap gap-3">
+                <a href={p.ctas.primary.href} className="button type1" aria-label={tr(p.ctas.primary.labelKey)}>
+                  <span className="btn-txt">{tr(p.ctas.primary.labelKey)}</span>
+                </a>
+
+                {p.ctas.secondary && (
+                  <a href={p.ctas.secondary.href} className="rounded-2xl border px-4 py-2 text-sm">
+                    {tr(p.ctas.secondary.labelKey)}
+                  </a>
+                )}
+
+                {p.ctas.whatsapp && (
+                  <a
+                    href={p.ctas.whatsapp.href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="rounded-2xl border px-4 py-2 text-sm"
+                  >
+                    {tr(p.ctas.whatsapp.labelKey)}
+                  </a>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/data/packs.ts
+++ b/src/data/packs.ts
@@ -1,91 +1,78 @@
 export type Pack = {
-  id: "starter" | "growth" | "custom";
-  title: string;
-  tagline: string;
-  priceLine: string;
-  features: string[]; // visibles en liste
-  extras: string[];   // masquées tant que "Voir tout le contenu" n’est pas ouvert
+  id: string;
+  tag?: "Basique" | "Populaire" | "Premium";
+  titleKey: string;
+  subtitleKey: string;
+  priceKey: string;
+  perMonthKey?: string;
+  badges: string[];
+  bullets: string[];
+  ctas: {
+    primary: { labelKey: string; href: string };
+    secondary?: { labelKey: string; href: string };
+    whatsapp?: { labelKey: string; href: string };
+  };
 };
 
 export const packs: Pack[] = [
   {
     id: "starter",
-    title: "Pack Découverte",
-    tagline: "Lancez-vous dès aujourd’hui",
-    priceLine: "à partir de 49€",
-    features: [
-      "Visuel unique (logo simple / bannière / 3 posts)",
-      "Landing 1 section (Héros + CTA + formulaire)",
-      "Mini‑workflow (Form → Email)",
-      "Montage vidéo ≤45s ou 10 retouches photo",
-      "Visio 30 min + notes d’actions",
-      "FAQ IA basique (widget 20 Q/R)"
+    tag: "Basique",
+    titleKey: "offers.starter.title",
+    subtitleKey: "offers.starter.subtitle",
+    priceKey: "offers.starter.price",
+    badges: ["offers.badge.fast", "offers.badge.basic", "offers.badge.onboarding"],
+    bullets: [
+      "offers.starter.b1",
+      "offers.starter.b2",
+      "offers.starter.b3",
+      "offers.starter.b4",
+      "offers.starter.b5"
     ],
-    extras: [
-      "SEO base : titles/meta, balises, Open Graph, favicon",
-      "Sitemap.xml + robots.txt",
-      "Accessibilité AA de base (contrastes, aria, keyboard)",
-      "Perf & qualité : images optimisées, lazy‑load, audit rapide",
-      "Analytics léger (pageview) + consentement cookies basique",
-      "Formulaire relié à Email (ou webhook) + capture Notion/Sheets",
-      "Hébergement & déploiement (Netlify/Vercel) + domaine/DNS",
-      "Page Mentions légales & Politique de confidentialité (modèles)",
-      "Petit kit de marque : variations logo + 1 template post",
-      "Onboarding 30 min + vidéo récap / mini‑doc utilisateur"
-    ]
+    ctas: {
+      primary: { labelKey: "offers.cta.startNow", href: "#contact" },
+      whatsapp: { labelKey: "offers.cta.whatsapp", href: "https://wa.me/33743561304" }
+    }
   },
   {
     id: "growth",
-    title: "Pack Croissance",
-    tagline: "Passez à la vitesse supérieure",
-    priceLine: "à partir de 249€ (ou 3× 89€/mois)",
-    features: [
-      "Mini‑site 3 sections (SEO base + analytics)",
-      "15 posts + 1 micro‑vidéo (calendrier Notion)",
-      "Workflow utile (Form → Sheets + email + notif)",
-      "Vidéo ≤90s ou 20 retouches (cut + transitions)",
-      "Audit express + plan 30/60/90 (visio 45 min)",
-      "Chatbot FAQ IA (50 Q/R + capture email)"
+    tag: "Populaire",
+    titleKey: "offers.growth.title",
+    subtitleKey: "offers.growth.subtitle",
+    priceKey: "offers.growth.price",
+    perMonthKey: "offers.growth.perMonth",
+    badges: ["offers.badge.site", "offers.badge.social", "offers.badge.ai"],
+    bullets: [
+      "offers.growth.b1",
+      "offers.growth.b2",
+      "offers.growth.b3",
+      "offers.growth.b4",
+      "offers.growth.b5"
     ],
-    extras: [
-      "Blog léger (MDX/Notion) + plan de contenu 1 mois",
-      "Automations no‑code : Zapier/Make (CRM Notion/Sheets)",
-      "CRM pipeline simple (acquisition → devis → suivi)",
-      "Emailing transactionnel (EmailJS/Resend) + modèles",
-      "SEO renforcé : plan sémantique, maillage, redirections",
-      "Performance : code‑split, images responsives, pré‑fetch",
-      "Formulaires multi‑étapes + validation + anti‑spam",
-      "Calendly/Meet intégré (prise de RDV) + page Merci",
-      "Tableau de bord Notion : KPIs trafic + pipeline + contenu",
-      "Kit social : 15 posts programmables + 1 gabarit vidéo",
-      "Onboarding 1h + 1 semaine de support email"
-    ]
+    ctas: {
+      primary: { labelKey: "offers.cta.bookPack", href: "#contact" },
+      whatsapp: { labelKey: "offers.cta.whatsapp", href: "https://wa.me/33743561304" }
+    }
   },
   {
     id: "custom",
-    title: "Pack Sur‑mesure",
-    tagline: "Votre projet clé en main",
-    priceLine: "à partir de 799€ (ou 3× 270€/mois)",
-    features: [
-      "Site 5–7 sections / Petite boutique (Stripe + 2 automatisations)",
-      "Gestion réseaux 1 mois (30 posts, 4 reels, 1 ads)",
-      "Ops simple (×3 workflows) + dashboard Notion/Sheets",
-      "Agent IA avancé (RAG + multi‑langues)",
-      "Accompagnement 1 mois (4 visios, roadmap Notion)",
-      "Setup express (checklists + modèles + banques)"
+    tag: "Premium",
+    titleKey: "offers.custom.title",
+    subtitleKey: "offers.custom.subtitle",
+    priceKey: "offers.custom.price",
+    perMonthKey: "offers.custom.perMonth",
+    badges: ["offers.badge.integrations", "offers.badge.aiAdvanced", "offers.badge.automations"],
+    bullets: [
+      "offers.custom.b1",
+      "offers.custom.b2",
+      "offers.custom.b3",
+      "offers.custom.b4",
+      "offers.custom.b5"
     ],
-    extras: [
-      "E‑commerce : Stripe (produits, checkout, coupons, webhooks)",
-      "Internationalisation FR/EN (i18n) + SEO multilingue",
-      "Recherche & Chat IA (RAG) : corpus Notion/Docs/URL",
-      "Intégrations : Supabase/DB, stockage, email, webhooks",
-      "Sécurité : en‑têtes, rate‑limit de base, honeypot, logs",
-      "Accessibilité avancée, tests, audits Lighthouse",
-      "Animations Framer Motion, sections premium (Hero 3D/Canvas)",
-      "Pages légales complètes (RGPD/UK) + bandeau cookies",
-      "Monitoring & alertes (uptime, erreurs) + sauvegardes",
-      "CI/CD & environnements (preview/staging) + secrets",
-      "Formation équipe (2h) + support 1 mois (SLA léger)"
-    ]
+    ctas: {
+      primary: { labelKey: "offers.cta.quote", href: "#contact" },
+      secondary: { labelKey: "offers.cta.bookMeeting", href: "#contact" },
+      whatsapp: { labelKey: "offers.cta.whatsapp", href: "https://wa.me/33743561304" }
+    }
   }
 ];

--- a/src/data/translations.ts
+++ b/src/data/translations.ts
@@ -27,10 +27,10 @@ export interface Translation {
       invest: string;
     };
   };
-    about: {
-      title: string;
-      content: string;
-    };
+  about: {
+    title: string;
+    content: string;
+  };
   common: {
     links: {
       blog: string;
@@ -65,6 +65,63 @@ export interface Translation {
       fiverr: string;
       linkedin: string;
       github: string;
+    };
+  };
+  offers: {
+    title: string;
+    subtitle: string;
+    whichPack: string;
+    tag: { basique: string; populaire: string; premium: string };
+    badge: {
+      fast: string;
+      basic: string;
+      onboarding: string;
+      site: string;
+      social: string;
+      ai: string;
+      integrations: string;
+      aiAdvanced: string;
+      automations: string;
+    };
+    cta: {
+      startNow: string;
+      bookPack: string;
+      quote: string;
+      bookMeeting: string;
+      whatsapp: string;
+    };
+    starter: {
+      title: string;
+      subtitle: string;
+      price: string;
+      perMonth: string;
+      b1: string;
+      b2: string;
+      b3: string;
+      b4: string;
+      b5: string;
+    };
+    growth: {
+      title: string;
+      subtitle: string;
+      price: string;
+      perMonth: string;
+      b1: string;
+      b2: string;
+      b3: string;
+      b4: string;
+      b5: string;
+    };
+    custom: {
+      title: string;
+      subtitle: string;
+      price: string;
+      perMonth: string;
+      b1: string;
+      b2: string;
+      b3: string;
+      b4: string;
+      b5: string;
     };
   };
   portfolio: {
@@ -138,6 +195,63 @@ export const translations: Record<Language, Translation> = {
         github: 'GitHub',
       },
     },
+    offers: {
+      title: 'Offres & Prestations',
+      subtitle: 'Choisissez un pack selon votre objectif. Les tarifs sont “à partir de” et ajustés selon votre contexte.',
+      whichPack: 'Quel pack est fait pour vous ?',
+      tag: { basique: 'Basique', populaire: 'Populaire', premium: 'Premium' },
+      badge: {
+        fast: 'Rapide',
+        basic: 'Basique',
+        onboarding: 'Prise en main',
+        site: 'Site',
+        social: 'Social',
+        ai: 'IA',
+        integrations: 'Intégrations',
+        aiAdvanced: 'IA avancée',
+        automations: 'Automations',
+      },
+      cta: {
+        startNow: 'Je commence aujourd’hui',
+        bookPack: 'Réserver ce pack',
+        quote: 'Obtenir mon devis gratuit',
+        bookMeeting: 'Réserver un RDV',
+        whatsapp: 'WhatsApp',
+      },
+      starter: {
+        title: 'Pack Découverte',
+        subtitle: 'Lancez-vous dès aujourd’hui',
+        price: 'à partir de 49€',
+        perMonth: '',
+        b1: 'Visuel unique (logo simple / bannière / 3 posts)',
+        b2: 'Landing 1 section (Héros + CTA + formulaire)',
+        b3: 'Mini-workflow (Form → Email)',
+        b4: 'Montage vidéo ≤45s ou 10 retouches photo',
+        b5: 'Visio 30 min + notes d’actions',
+      },
+      growth: {
+        title: 'Pack Croissance',
+        subtitle: 'Passez à la vitesse supérieure',
+        price: 'à partir de 249€',
+        perMonth: 'ou 3× 89€/mois',
+        b1: 'Mini-site 3 sections (SEO base + analytics)',
+        b2: '15 posts + 1 micro‑vidéo (calendrier Notion)',
+        b3: 'Workflow utile (Form → Sheets + email + notif)',
+        b4: 'Vidéo ≤90s ou 20 retouches (cut + transitions)',
+        b5: 'Audit express + plan 30/60/90 (visio 45 min)',
+      },
+      custom: {
+        title: 'Pack Sur‑mesure',
+        subtitle: 'Votre projet clé en main',
+        price: 'à partir de 799€',
+        perMonth: 'ou 3× 270€/mois',
+        b1: 'Site 5–7 sections / Petite boutique (Stripe + 2 automatisations)',
+        b2: 'Gestion réseaux 1 mois (30 posts, 4 reels, 1 ads)',
+        b3: 'Ops simple (x3 workflows) + dashboard Notion/Sheets',
+        b4: 'Agent IA avancé (RAG + multi‑langues)',
+        b5: 'Setup express (checklists + modèles + banques)',
+      },
+    },
     portfolio: {
       karim: 'Portfolio Karim',
       raphael: 'Portfolio Raphaël',
@@ -205,6 +319,63 @@ export const translations: Record<Language, Translation> = {
         fiverr: 'Fiverr',
         linkedin: 'LinkedIn',
         github: 'GitHub',
+      },
+    },
+    offers: {
+      title: 'Offers & Services',
+      subtitle: 'Pick a pack for your goal. Prices are “from” and adjusted to your context.',
+      whichPack: 'Which pack is right for you?',
+      tag: { basique: 'Basic', populaire: 'Popular', premium: 'Premium' },
+      badge: {
+        fast: 'Fast',
+        basic: 'Basic',
+        onboarding: 'Onboarding',
+        site: 'Website',
+        social: 'Social',
+        ai: 'AI',
+        integrations: 'Integrations',
+        aiAdvanced: 'Advanced AI',
+        automations: 'Automations',
+      },
+      cta: {
+        startNow: 'Start today',
+        bookPack: 'Book this pack',
+        quote: 'Get my free quote',
+        bookMeeting: 'Book a meeting',
+        whatsapp: 'WhatsApp',
+      },
+      starter: {
+        title: 'Starter Pack',
+        subtitle: 'Get launched today',
+        price: 'from €49',
+        perMonth: '',
+        b1: 'One visual (simple logo / banner / 3 posts)',
+        b2: 'One-section landing (Hero + CTA + form)',
+        b3: 'Mini-workflow (Form → Email)',
+        b4: 'Video edit ≤45s or 10 photo edits',
+        b5: '30-min call + action notes',
+      },
+      growth: {
+        title: 'Growth Pack',
+        subtitle: 'Shift into higher gear',
+        price: 'from €249',
+        perMonth: 'or 3× €89/mo',
+        b1: 'Mini-site 3 sections (basic SEO + analytics)',
+        b2: '15 posts + 1 micro-video (Notion calendar)',
+        b3: 'Useful workflow (Form → Sheets + email + notif)',
+        b4: 'Video ≤90s or 20 edits (cuts + transitions)',
+        b5: 'Express audit + 30/60/90 plan (45-min call)',
+      },
+      custom: {
+        title: 'Custom Pack',
+        subtitle: 'Turn-key project',
+        price: 'from €799',
+        perMonth: 'or 3× €270/mo',
+        b1: '5–7-section site / Small shop (Stripe + 2 automations)',
+        b2: '1-month social mgmt (30 posts, 4 reels, 1 ad)',
+        b3: 'Simple ops (x3 workflows) + Notion/Sheets dashboard',
+        b4: 'Advanced AI agent (RAG + multi-language)',
+        b5: 'Express setup (checklists + templates + banks)',
       },
     },
     portfolio: {


### PR DESCRIPTION
## Summary
- rebuild "Offres & Prestations" section with three translated packs and WhatsApp CTAs
- integrate OffersSection and budget quiz on main page with FR/EN strings

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689b56c2ba1c83318233c11f7bf9635e