### PR TITLE
feat(offers): restore offers section with i18n + whatsapp

### DIFF
--- a/src/components/OffersSection.tsx
+++ b/src/components/OffersSection.tsx
@@ -19,7 +19,7 @@ export default function OffersSection() {
           <h2 className="text-3xl sm:text-4xl font-bold">{tr("offers.title")}</h2>
           <p className="mt-2 text-base sm:text-lg opacity-80">{tr("offers.subtitle")}</p>
           <div className="mt-4">
-            <a href="#pack-quiz" className="inline-block rounded-2xl border px-4 py-2 text-sm">
+            <a href="#quiz-budget" className="inline-block rounded-2xl border px-4 py-2 text-sm">
               {tr("offers.whichPack")}
             </a>
           </div>

--- a/src/components/pricing/QuizPack.tsx
+++ b/src/components/pricing/QuizPack.tsx
@@ -63,7 +63,7 @@ export default function QuizPack() {
     return (
       <section className="w-full bg-[#0B0B0C] py-12">
         <div className="mx-auto max-w-3xl px-4 text-center text-gray-200">
-          <span id="pack-quiz" className="block relative -top-20" />
+          <span id="quiz-budget" className="block relative -top-20" />
           <h2 className="text-2xl font-bold text-white mb-4">Votre pack recommandé</h2>
           <p className="mb-6">
             Nous vous conseillons le <span className="font-semibold">{planLabel}</span>.
@@ -93,7 +93,7 @@ export default function QuizPack() {
     <section className="w-full bg-[#0B0B0C] py-12">
       <div className="mx-auto max-w-3xl px-4 text-center text-gray-200">
         {/* anchor for smooth scroll from Offres CTA */}
-        <span id="pack-quiz" className="block relative -top-20" />
+        <span id="quiz-budget" className="block relative -top-20" />
         <h2 className="text-2xl font-bold text-white mb-6">Quel pack est fait pour vous ?</h2>
         <p className="mb-4 text-sm">{current.q}</p>
         <div className="flex flex-col items-center gap-3">


### PR DESCRIPTION
## Summary
- link offers CTA to quiz budget anchor
- align quiz anchor ids with CTA

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b5c3a53cc83319ca4b9eacb571336