### PR TITLE
feat: add multilingual Calendly popup and badge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Footer } from './components/Footer';
 import OffersSection from '@/components/OffersSection';
 import QuizPack from '@/components/pricing/QuizPack';
 import { ENABLE_DZ_PARTICLES, SHOW_PRICING } from './featureFlags';
+import CalendlyLoader from '@/app/_components/CalendlyLoader';
 
 const DarkZoneParticles = React.lazy(() => import('./components/DarkZoneParticles'));
 // FAQ (lazy universel)
@@ -34,6 +35,7 @@ function App() {
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
     >
+      <CalendlyLoader />
       <Header
         currentLanguage={currentLanguage}
         onLanguageChange={changeLanguage}

--- a/src/app/_components/CalendlyButton.tsx
+++ b/src/app/_components/CalendlyButton.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Lang = "en" | "fr";
+
+const LABEL = {
+  en: "Book a 30‑min call",
+  fr: "Réserver 30 min",
+};
+
+function detectLang(): Lang {
+  try {
+    const fromLS = localStorage.getItem("lang") || "";
+    if (/^(en|fr)$/i.test(fromLS)) return fromLS.toLowerCase() as Lang;
+  } catch { /* ignore */ }
+  const fromHtml = document.documentElement.getAttribute("lang") || "";
+  if (/^(en|fr)$/i.test(fromHtml)) return fromHtml.toLowerCase() as Lang;
+  const fromData =
+    (document.body?.dataset?.lang || document.documentElement?.dataset?.lang || "").toString();
+  if (/^(en|fr)$/i.test(fromData)) return fromData.toLowerCase() as Lang;
+  return "en";
+}
+
+export default function CalendlyButton({ className = "" }: { className?: string }) {
+  const [label, setLabel] = useState(LABEL.en);
+
+  useEffect(() => {
+    const lang = detectLang();
+    setLabel(LABEL[lang]);
+
+    // observe changes
+    const mo = new MutationObserver(() => {
+      const d = detectLang();
+      setLabel(LABEL[d]);
+    });
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ["lang", "data-lang"] });
+    return () => mo.disconnect();
+  }, []);
+
+  return (
+    <button
+      data-calendly-btn
+      onClick={() => window.openCalendly?.()}
+      className={`px-4 py-2 rounded-full border border-neutral-900 bg-neutral-900 text-white hover:opacity-90 transition ${className}`}
+      aria-label="Open Calendly popup"
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}
+

--- a/src/app/_components/CalendlyLoader.tsx
+++ b/src/app/_components/CalendlyLoader.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Lang = "en" | "fr";
+
+const URLS: Record<Lang, string> = {
+  en: "https://calendly.com/krglobalsolutionsltd/30-minute-meeting-clone",
+  fr: "https://calendly.com/krglobalsolutionsltd/30min",
+};
+
+const TXT = {
+  en: { button: "Book a 30‑min call", badge: "Book a call" },
+  fr: { button: "Réserver 30 min", badge: "Réserver un appel" },
+};
+
+function detectLang(): Lang {
+  try {
+    const fromLS = (typeof localStorage !== "undefined" && localStorage.getItem("lang")) || "";
+    if (/^(en|fr)$/i.test(fromLS)) return fromLS.toLowerCase() as Lang;
+  } catch { /* ignore */ }
+  const fromHtml = document.documentElement.getAttribute("lang") || "";
+  if (/^(en|fr)$/i.test(fromHtml)) return fromHtml.toLowerCase() as Lang;
+  const fromData =
+    (document.body?.dataset?.lang || document.documentElement?.dataset?.lang || "").toString();
+  if (/^(en|fr)$/i.test(fromData)) return fromData.toLowerCase() as Lang;
+  return "en";
+}
+
+declare global {
+  interface CalendlyWidget {
+    initPopupWidget: (opts: { url: string }) => void;
+    initBadgeWidget: (opts: {
+      url: string;
+      text: string;
+      color: string;
+      textColor: string;
+      branding: boolean;
+    }) => void;
+  }
+
+  interface Window {
+    Calendly?: CalendlyWidget;
+    openCalendly?: () => boolean;
+    setSiteLang?: (lang: Lang) => void;
+  }
+}
+
+export default function CalendlyLoader() {
+  const [lang, setLang] = useState<Lang>("en");
+  const moRef = useRef<MutationObserver | null>(null);
+
+  // Load external Calendly script once
+  useEffect(() => {
+    const id = "calendly-widget-js";
+    if (!document.getElementById(id)) {
+      const s = document.createElement("script");
+      s.id = id;
+      s.async = true;
+      s.src = "https://assets.calendly.com/assets/external/widget.js";
+      document.body.appendChild(s);
+    }
+  }, []);
+
+  // Expose openCalendly()
+  useEffect(() => {
+    window.openCalendly = () => {
+      const url = URLS[lang];
+      if (window.Calendly) {
+        window.Calendly.initPopupWidget({ url });
+        return false;
+      }
+      window.location.href = url; // fallback
+      return false;
+    };
+  }, [lang]);
+
+  // Initialize + react to language changes
+  useEffect(() => {
+    function applyLanguage(next: Lang) {
+      setLang(next);
+      // When Calendly is ready, (re)init badge
+      const tick = setInterval(() => {
+        if (window.Calendly) {
+          // Remove old badges (Calendly n'a pas d'API destroy officielle)
+          document.querySelectorAll("[data-calendly-badge]").forEach((n) => n.remove());
+          // marker pour clean possible
+          const marker = document.createElement("div");
+          marker.setAttribute("data-calendly-badge", "1");
+          document.body.appendChild(marker);
+          window.Calendly.initBadgeWidget({
+            url: URLS[next],
+            text: TXT[next].badge,
+            color: "#111111",
+            textColor: "#ffffff",
+            branding: true,
+          });
+          clearInterval(tick);
+        }
+      }, 100);
+      setTimeout(() => clearInterval(tick), 8000);
+      // Update any data-i18n label on buttons
+      document.querySelectorAll<HTMLElement>("[data-calendly-btn]").forEach((el) => {
+        el.innerText = TXT[next].button;
+      });
+    }
+
+    // initial
+    applyLanguage(detectLang());
+
+    // observe <html lang="..">
+    if (!moRef.current) {
+      moRef.current = new MutationObserver(() => {
+        const d = detectLang();
+        if (d !== lang) applyLanguage(d);
+      });
+      moRef.current.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["lang", "data-lang"],
+      });
+    }
+
+    // intercept localStorage('lang') changes
+    const orig = localStorage.setItem;
+    // @ts-expect-error override for lang change detection
+    localStorage.setItem = function (k: string, v: string) {
+      const res = orig.apply(this, [k, v]);
+      if (k === "lang") {
+        const d = detectLang();
+        if (d !== lang) applyLanguage(d);
+      }
+      return res;
+    };
+
+    // manual API if needed
+    window.setSiteLang = (l: Lang) => {
+      document.documentElement.setAttribute("lang", l);
+      try { localStorage.setItem("lang", l); } catch { /* ignore */ }
+      applyLanguage(l);
+    };
+
+    return () => {
+      if (moRef.current) moRef.current.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null; // loader invisible
+}
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,1 @@
+@import "../index.css";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import CalendlyLoader from "./_components/CalendlyLoader";
+
+export const metadata: Metadata = {
+  title: "KR Global Solutions",
+  description: "Solutions digitales, e-commerce et technologies pour demain.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="fr">
+      <body>
+        {/* Loader invisible: charge Calendly + sync langue + badge */}
+        <CalendlyLoader />
+        {children}
+      </body>
+    </html>
+  );
+}
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { Language, Translation } from '../data/translations';
 import KRLogoKR from "@/components/KRLogoKR";
 import { DarkZoneToggle } from './DarkZoneToggle';
 import { Menu, X } from "lucide-react";
-const CalendlyPopupButton = React.lazy(() => import("@/components/CalendlyPopup").then(m => ({ default: m.CalendlyPopupButton })));
+import CalendlyButton from "@/app/_components/CalendlyButton";
 
 interface HeaderProps {
   currentLanguage: Language;
@@ -33,16 +33,7 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
           <DarkZoneToggle label={t.nav.darkZone} />
         </div>
         <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
-          <React.Suspense fallback={null}>
-            <CalendlyPopupButton
-              label={
-                typeof document !== 'undefined' && document.documentElement.lang?.startsWith('fr')
-                  ? 'Réserver un appel'
-                  : 'Book a call'
-              }
-              className="px-4 py-2 rounded-2xl border text-sm"
-            />
-          </React.Suspense>
+          <CalendlyButton className="hidden sm:inline-flex text-sm" />
           <SocialLinks variant="header" size={20} className="justify-end hidden md:flex" />
           <button
             className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50"

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import InfiniteHeadline from '@/components/InfiniteHeadline';
 import { Translation } from '../data/translations';
 import HeroVideoCompat from '@/components/HeroVideoCompat';
+import CalendlyButton from '@/app/_components/CalendlyButton';
 
 interface HeroSectionProps {
   t: Translation;
@@ -28,6 +29,9 @@ export function HeroSection({ t }: HeroSectionProps) {
           {/* --- Video placed directly under the subtitle --- */}
           <div className="mt-6 md:mt-8">
             <HeroVideoCompat />
+          </div>
+          <div className="mt-6">
+            <CalendlyButton />
           </div>
         </motion.div>
       </div>


### PR DESCRIPTION
## Summary
- add Calendly loader to expose `openCalendly` and badge with language auto-detection
- create reusable CalendlyButton and place it in navbar and hero
- load Calendly script in layout to handle language sync across site

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689c52f0242083319bafb692a942cde4