### PR TITLE
feat: improve Calendly handling and add booking page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -15,7 +15,7 @@
     },
     "cta": {
       "startNow": "Start today", "bookPack": "Book this pack",
-      "quote": "Get my free quote", "bookMeeting": "Book a meeting", "whatsapp": "WhatsApp"
+        "quote": "Get my free quote", "bookMeeting": "Book 30 min", "whatsapp": "WhatsApp"
     },
     "starter": {
       "title": "Starter Pack", "subtitle": "Get launched today",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -15,7 +15,7 @@
     },
     "cta": {
       "startNow": "Je commence aujourd’hui", "bookPack": "Réserver ce pack",
-      "quote": "Obtenir mon devis gratuit", "bookMeeting": "Réserver un RDV", "whatsapp": "WhatsApp"
+        "quote": "Obtenir mon devis gratuit", "bookMeeting": "RDV 30 min", "whatsapp": "WhatsApp"
     },
     "starter": {
       "title": "Pack Découverte", "subtitle": "Lancez-vous dès aujourd’hui",

--- a/src/app/_components/CalendlyManager.tsx
+++ b/src/app/_components/CalendlyManager.tsx
@@ -1,0 +1,120 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+type Lang = "en" | "fr";
+
+const URLS: Record<Lang, string> = {
+  en: "https://calendly.com/krglobalsolutionsltd/30-minute-meeting-clone",
+  fr: "https://calendly.com/krglobalsolutionsltd/30min",
+};
+
+function detectLang(): Lang {
+  try {
+    const ls = localStorage.getItem("lang");
+    if (ls && /^(en|fr)$/i.test(ls)) return ls.toLowerCase() as Lang;
+  } catch { /* empty */ }
+  const html = document.documentElement.getAttribute("lang");
+  if (html && /^(en|fr)$/i.test(html)) return html.toLowerCase() as Lang;
+  const data =
+    (document.body?.dataset?.lang || document.documentElement?.dataset?.lang || "").toString();
+  if (data && /^(en|fr)$/i.test(data)) return data.toLowerCase() as Lang;
+  return "fr";
+}
+
+interface CalendlyWidget {
+  initPopupWidget?: (opts: { url: string }) => void;
+}
+
+declare global {
+  interface Window {
+    Calendly?: CalendlyWidget;
+    openCalendly?: (prefer?: "popup" | "tab") => boolean;
+    getCalendlyUrl?: () => string;
+  }
+}
+
+export default function CalendlyManager() {
+  const [lang, setLang] = useState<Lang>("fr");
+  const moRef = useRef<MutationObserver | null>(null);
+
+  // charger script Calendly une seule fois
+  useEffect(() => {
+    const id = "calendly-widget-js";
+    if (!document.getElementById(id)) {
+      const s = document.createElement("script");
+      s.id = id;
+      s.async = true;
+      s.src = "https://assets.calendly.com/assets/external/widget.js";
+      document.body.appendChild(s);
+    }
+  }, []);
+
+  // --- FIX scroll lock : Calendly ajoute overflow:hidden sur <html>/<body>.
+  function unlockScroll() {
+    document.documentElement.style.overflow = "";
+    document.body.style.overflow = "";
+    // retire overlay si resté orphelin
+    document.querySelectorAll(".calendly-overlay, [data-calendly-badge]").forEach((n) => {
+      // ne supprime pas le badge officiel, juste les overlays restants
+      if ((n as HTMLElement).classList.contains("calendly-overlay")) n.remove();
+    });
+  }
+
+  // Observe l’overlay pour détecter fermeture et débloquer le scroll
+  useEffect(() => {
+    const obs = new MutationObserver(() => {
+      const overlay = document.querySelector(".calendly-overlay");
+      if (!overlay) unlockScroll();
+    });
+    obs.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") setTimeout(unlockScroll, 50);
+    });
+    return () => obs.disconnect();
+  }, []);
+
+  // expose helpers
+  useEffect(() => {
+    window.getCalendlyUrl = () => URLS[lang];
+    window.openCalendly = (prefer: "popup" | "tab" = "popup") => {
+      const url = URLS[lang];
+      if (prefer === "tab") {
+        window.open(url, "_blank", "noopener,noreferrer");
+        return false;
+      }
+      if (window.Calendly?.initPopupWidget) {
+        window.Calendly.initPopupWidget({ url });
+        // Calendly ferme tout seul, mais on planifie un cleanup de sécurité
+        setTimeout(unlockScroll, 4000);
+        return false;
+      }
+      // fallback : nouvelle page
+      window.open(url, "_blank", "noopener,noreferrer");
+      return false;
+    };
+  }, [lang]);
+
+  // sync langue + écouter changements
+  useEffect(() => {
+    const apply = () => setLang(detectLang());
+    apply();
+    if (!moRef.current) {
+      moRef.current = new MutationObserver(apply);
+      moRef.current.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["lang", "data-lang"],
+      });
+    }
+    const orig = localStorage.setItem;
+    // @ts-expect-error override for lang change detection
+    localStorage.setItem = function (k: string, v: string) {
+      const r = orig.apply(this, [k, v]);
+      if (k === "lang") apply();
+      return r;
+    };
+    return () => moRef.current?.disconnect();
+  }, []);
+
+  return null;
+}
+

--- a/src/app/_components/HeaderBookingLink.tsx
+++ b/src/app/_components/HeaderBookingLink.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const LABEL = { fr: "Réserver 30 min", en: "Book 30 min" } as const;
+
+function detect() {
+  try { const ls = localStorage.getItem("lang"); if (ls) return ls; } catch { /* empty */ }
+  return document.documentElement.getAttribute("lang") || "fr";
+}
+
+export function HeaderBookingLink({ className = "" }: { className?: string }) {
+  const [lang, setLang] = useState<"fr" | "en">(detect() === "en" ? "en" : "fr");
+  useEffect(() => {
+    const mo = new MutationObserver(() => setLang(detect() === "en" ? "en" : "fr"));
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ["lang"] });
+    return () => mo.disconnect();
+  }, []);
+  return (
+    <a
+      href={typeof window !== "undefined" && window.getCalendlyUrl ? window.getCalendlyUrl() : "#"}
+      onClick={(e) => {
+        e.preventDefault();
+        window.openCalendly?.("tab");
+      }}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`px-4 py-2 rounded-full bg-neutral-900 text-white hover:opacity-90 transition ${className}`}
+    >
+      {LABEL[lang]}
+    </a>
+  );
+}
+

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useEffect, useState } from "react";
+
+type Lang = "en" | "fr";
+const URLS = {
+  en: "https://calendly.com/krglobalsolutionsltd/30-minute-meeting-clone",
+  fr: "https://calendly.com/krglobalsolutionsltd/30min",
+};
+
+export default function BookingPage() {
+  const [lang, setLang] = useState<Lang>("fr");
+  useEffect(() => {
+    const get = () => {
+      try {
+        const ls = localStorage.getItem("lang");
+        if (ls && /^(en|fr)$/i.test(ls)) return ls.toLowerCase() as Lang;
+      } catch { /* empty */ }
+      const html = document.documentElement.getAttribute("lang");
+      if (html && /^(en|fr)$/i.test(html)) return html.toLowerCase() as Lang;
+      return "fr";
+    };
+    const apply = () => setLang(get());
+    apply();
+    const mo = new MutationObserver(apply);
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ["lang"] });
+    return () => mo.disconnect();
+  }, []);
+
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-semibold mb-3">
+        {lang === "fr" ? "Réserver un créneau" : "Book a slot"}
+      </h1>
+      <p className="text-sm text-neutral-500 mb-6">
+        {lang === "fr"
+          ? "Choisissez l’horaire qui vous convient. La prise de rendez-vous se fait directement depuis cette page."
+          : "Pick a time that works for you. You can schedule directly below."}
+      </p>
+
+      <div className="rounded-2xl overflow-hidden border border-neutral-200">
+        <iframe
+          key={lang}
+          src={URLS[lang]}
+          title="Calendly"
+          className="w-full"
+          style={{ height: 820, border: 0 }}
+        />
+      </div>
+    </main>
+  );
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import CalendlyLoader from "./_components/CalendlyLoader";
+import CalendlyManager from "./_components/CalendlyManager";
 
 export const metadata: Metadata = {
   title: "KR Global Solutions",
@@ -11,8 +11,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="fr">
       <body>
-        {/* Loader invisible: charge Calendly + sync langue + badge */}
-        <CalendlyLoader />
+        <CalendlyManager />
         {children}
       </body>
     </html>

--- a/src/components/BookCta.tsx
+++ b/src/components/BookCta.tsx
@@ -4,8 +4,8 @@ export default function BookCta() {
   const isEN = prefix === '/en';
 
   return (
-    <a href={`${prefix}/book`} className="btn btn-primary">
-      {isEN ? 'Book a call' : 'Réserver un RDV'}
-    </a>
+      <a href={`${prefix}/book`} className="btn btn-primary">
+        {isEN ? 'Book 30 min' : 'RDV 30 min'}
+      </a>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { Language, Translation } from '../data/translations';
 import KRLogoKR from "@/components/KRLogoKR";
 import { DarkZoneToggle } from './DarkZoneToggle';
 import { Menu, X } from "lucide-react";
-import CalendlyButton from "@/app/_components/CalendlyButton";
+import { HeaderBookingLink } from "@/app/_components/HeaderBookingLink";
 
 interface HeaderProps {
   currentLanguage: Language;
@@ -33,7 +33,7 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
           <DarkZoneToggle label={t.nav.darkZone} />
         </div>
         <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
-          <CalendlyButton className="hidden sm:inline-flex text-sm" />
+          <HeaderBookingLink className="hidden sm:inline-flex text-sm" />
           <SocialLinks variant="header" size={20} className="justify-end hidden md:flex" />
           <button
             className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50"

--- a/src/components/OffersSection.tsx
+++ b/src/components/OffersSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 
 /** Types locaux (évite les imports qui cassent le build) */
 type Pack = {
@@ -42,7 +43,7 @@ const FALLBACK_DICT = {
         startNow: "Je commence aujourd’hui",
         bookPack: "Réserver ce pack",
         quote: "Obtenir mon devis gratuit",
-        bookMeeting: "Réserver un RDV",
+        bookMeeting: "RDV 30 min",
         whatsapp: "WhatsApp",
       },
       starter: {
@@ -98,13 +99,13 @@ const FALLBACK_DICT = {
         aiAdvanced: "Advanced AI",
         automations: "Automations",
       },
-      cta: {
-        startNow: "Start today",
-        bookPack: "Book this pack",
-        quote: "Get my free quote",
-        bookMeeting: "Book a meeting",
-        whatsapp: "WhatsApp",
-      },
+        cta: {
+          startNow: "Start today",
+          bookPack: "Book this pack",
+          quote: "Get my free quote",
+          bookMeeting: "Book 30 min",
+          whatsapp: "WhatsApp",
+        },
       starter: {
         title: "Starter Pack",
         subtitle: "Get launched today",
@@ -359,13 +360,17 @@ export default function OffersSection() {
                   <span className="btn-txt">{tf(p.ctas.primary.labelKey)}</span>
                 </a>
                 {p.ctas.secondary && (
-                  <a
-                    href={p.ctas.secondary.href}
-                    className="rounded-2xl border px-4 py-2 text-sm"
-                  >
-                    {tf(p.ctas.secondary.labelKey)}
-                  </a>
-                )}
+                    <a
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        window.openCalendly?.("popup");
+                      }}
+                      className="rounded-2xl border px-4 py-2 text-sm"
+                    >
+                      {tf(p.ctas.secondary.labelKey)}
+                    </a>
+                  )}
                 {p.ctas.whatsapp && (
                   <a
                     href={p.ctas.whatsapp.href}
@@ -380,8 +385,13 @@ export default function OffersSection() {
             </article>
           ))}
         </div>
+        <div className="mt-4">
+          <Link href="/booking" className="underline text-sm opacity-80 hover:opacity-100">
+            Voir le calendrier intégré
+          </Link>
+        </div>
       </div>
-    </section>
+      </section>
   );
 }
 

--- a/src/data/translations.ts
+++ b/src/data/translations.ts
@@ -214,9 +214,9 @@ export const translations: Record<Language, Translation> = {
       cta: {
         startNow: 'Je commence aujourd’hui',
         bookPack: 'Réserver ce pack',
-        quote: 'Obtenir mon devis gratuit',
-        bookMeeting: 'Réserver un RDV',
-        whatsapp: 'WhatsApp',
+          quote: 'Obtenir mon devis gratuit',
+          bookMeeting: 'RDV 30 min',
+          whatsapp: 'WhatsApp',
       },
       starter: {
         title: 'Pack Découverte',
@@ -340,9 +340,9 @@ export const translations: Record<Language, Translation> = {
       cta: {
         startNow: 'Start today',
         bookPack: 'Book this pack',
-        quote: 'Get my free quote',
-        bookMeeting: 'Book a meeting',
-        whatsapp: 'WhatsApp',
+          quote: 'Get my free quote',
+          bookMeeting: 'Book 30 min',
+          whatsapp: 'WhatsApp',
       },
       starter: {
         title: 'Starter Pack',


### PR DESCRIPTION
## Summary
- add CalendlyManager client component to load Calendly safely, unlock scroll, and expose `openCalendly`
- replace header CTA with HeaderBookingLink opening in new tab and respect language
- update offer cards and translations to show **RDV 30 min**, hook buttons to Calendly popup, and add integrated booking page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689c71de8988833183e6c9c211aba95b