### PR TITLE
feat: add multilingual Calendly button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
         "@types/node": "^24.2.1",
         "clsx": "^2.1.0",
         "framer-motion": "^10.16.16",
+        "i18next": "^23.11.5",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-i18next": "^14.0.1",
         "react-icons": "^4.11.0",
         "three-stdlib": "^2.36.0",
         "tslib": "^2.8.1"
@@ -317,6 +319,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3077,6 +3088,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3103,6 +3123,29 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -4011,6 +4054,28 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.3.tgz",
+      "integrity": "sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-icons": {
@@ -5222,6 +5287,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "react-dom": "^18.3.1",
     "react-icons": "^4.11.0",
     "three-stdlib": "^2.36.0",
-    "tslib": "^2.8.1"
+    "tslib": "^2.8.1",
+    "i18next": "^23.11.5",
+    "react-i18next": "^14.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,4 +1,5 @@
 {
+  "bookMeeting": "Book a meeting",
   "portfolio": {
     "karim": "Karim's Portfolio",
     "raphael": "Raphaël's Portfolio"

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,4 +1,5 @@
 {
+  "bookMeeting": "Prendre rendez-vous",
   "portfolio": {
     "karim": "Portfolio Karim",
     "raphael": "Portfolio Raphaël"

--- a/src/components/CalendlyButton.tsx
+++ b/src/components/CalendlyButton.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+interface CalendlyButtonProps {
+  className?: string;
+}
+
+const CalendlyButton: React.FC<CalendlyButtonProps> = ({ className }) => {
+  const { i18n, t } = useTranslation();
+  const lang = i18n.language;
+
+  const calendlyLinks: Record<string, string> = {
+    en: "https://calendly.com/krglobalsolutionsltd/30-minute-meeting-clone",
+    fr: "https://calendly.com/krglobalsolutionsltd/30min",
+  };
+
+  const calendlyUrl = calendlyLinks[lang] || calendlyLinks.en;
+
+  return (
+    <a
+      href={calendlyUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`px-4 py-2 rounded-lg bg-primary text-white font-semibold hover:bg-primary/80 transition-colors ${className}`}
+    >
+      {t("bookMeeting")}
+    </a>
+  );
+};
+
+export default CalendlyButton;
+

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import CalendlyButton from '@/components/CalendlyButton';
+import { Translation } from '../data/translations';
+
+interface ContactProps {
+  t: Translation;
+}
+
+export default function Contact({ t }: ContactProps) {
+  return (
+    <section className="py-10">
+      <h2 className="text-2xl font-semibold">{t.contact.title}</h2>
+      <div className="mt-6">
+        <CalendlyButton />
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SocialLinks from '@/components/SocialLinks';
+import CalendlyButton from "@/components/CalendlyButton";
 
 export function Footer() {
   const pathname =
@@ -31,6 +32,7 @@ export function Footer() {
         </div>
         <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
           <SocialLinks variant="footer" size={22} className="justify-center sm:justify-end" />
+          <CalendlyButton className="mt-4" />
         </div>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { Language, Translation } from '../data/translations';
 import KRLogoKR from "@/components/KRLogoKR";
 import { DarkZoneToggle } from './DarkZoneToggle';
 import { Menu, X } from "lucide-react";
-import { HeaderBookingLink } from "@/app/_components/HeaderBookingLink";
+import CalendlyButton from "@/components/CalendlyButton";
 
 interface HeaderProps {
   currentLanguage: Language;
@@ -33,7 +33,7 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
           <DarkZoneToggle label={t.nav.darkZone} />
         </div>
         <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
-          <HeaderBookingLink className="hidden sm:inline-flex text-sm" />
+          <CalendlyButton className="ml-4 hidden sm:inline-flex text-sm" />
           <SocialLinks variant="header" size={20} className="justify-end hidden md:flex" />
           <button
             className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50"


### PR DESCRIPTION
## Summary
- add reusable CalendlyButton component selecting link per language
- localize meeting button text and expose in header, footer, and contact section
- include i18next dependencies for translations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689ea11dab708331a9b541535b3d526d