### PR TITLE
feat: integrate Calendly modal booking enhancer

### DIFF
--- a/src/bookingEnhancer.ts
+++ b/src/bookingEnhancer.ts
@@ -1,0 +1,84 @@
+import { CALENDLY } from "./config/booking";
+import { getCurrentLang } from "./utils/lang";
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+import { CalendlyEmbed } from "./components/booking/CalendlyEmbed";
+
+type BoundHTMLElement = HTMLElement & { __calendlyBound?: boolean };
+
+function openInNewTab(url: string) {
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+function ensurePortal() {
+  let host = document.getElementById("calendly-portal-root");
+  if (!host) {
+    host = document.createElement("div");
+    host.id = "calendly-portal-root";
+    document.body.appendChild(host);
+  }
+  return host;
+}
+
+function mountModal(url: string, title: string, description?: string) {
+  const host = ensurePortal();
+  const root = createRoot(host);
+  const ModalApp: React.FC = () => {
+    const [open, setOpen] = useState(true);
+    return React.createElement(CalendlyEmbed, {
+      isOpen: open,
+      onClose: () => setOpen(false),
+      url,
+      title,
+      description,
+    });
+  };
+  root.render(React.createElement(ModalApp));
+}
+
+function bindNode(el: BoundHTMLElement, mode: "tab" | "modal", url: string, lang: "fr" | "en") {
+  // Evite doublons
+  if (el.__calendlyBound) return;
+  el.__calendlyBound = true;
+
+  el.setAttribute("role", "button");
+  el.setAttribute("tabindex", "0");
+  el.addEventListener("keydown", (e) => (e.key === "Enter" || e.key === " ") && el.dispatchEvent(new Event("click")));
+
+  el.addEventListener("click", (e) => {
+    e.preventDefault();
+    if (mode === "modal") {
+      const title = lang === "en" ? "Book a 30‑minute call" : "Réserver 30 minutes";
+      const desc =
+        lang === "en"
+          ? "Pick a time to discuss your project with KR Global Solutions LTD."
+          : "Choisissez un créneau pour discuter de votre projet avec KR Global Solutions LTD.";
+      mountModal(url, title, desc);
+    } else {
+      openInNewTab(url);
+    }
+  });
+}
+
+export function attachCalendlyEnhancer() {
+  const lang = getCurrentLang();
+  const url = lang === "en" ? CALENDLY.en : CALENDLY.fr;
+
+  const all = Array.from(document.querySelectorAll<BoundHTMLElement>('[data-calendly="30min"]'));
+
+  // Cible préférée pour le MODAL (dernière card / Pack Sur‑mesure) si dispo :
+  let modalTarget: HTMLElement | null = null;
+  if (CALENDLY.modalTargetSelector) {
+    modalTarget = document.querySelector(CALENDLY.modalTargetSelector) as HTMLElement | null;
+  }
+  // Fallback : dernier bouton data-calendly de la page
+  if (!modalTarget && all.length > 0) {
+    modalTarget = all[all.length - 1]!;
+  }
+
+  // Bind : modal pour la cible, onglet pour les autres
+  all.forEach((el) => {
+    const mode: "tab" | "modal" = el === modalTarget ? "modal" : "tab";
+    bindNode(el, mode, url, lang);
+  });
+}

--- a/src/components/booking/CalendlyEmbed.tsx
+++ b/src/components/booking/CalendlyEmbed.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from "react";
+import { Modal } from "../ui/Modal";
+import { setPageSEO } from "../../utils/seo";
+
+type CalendlyEmbedProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  url: string;
+  title: string;
+  description?: string;
+};
+
+export const CalendlyEmbed: React.FC<CalendlyEmbedProps> = ({ isOpen, onClose, url, title, description }) => {
+  const src = useMemo(() => (isOpen ? url : ""), [isOpen, url]);
+  if (isOpen) {
+    setPageSEO(`${title} | KR Global Solutions LTD`, description || "Book a 30‑minute call with KR Global Solutions LTD");
+  }
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} titleId="calendly-title">
+      <h2 id="calendly-title" className="mb-3 text-xl font-semibold tracking-tight sm:text-2xl">
+        {title}
+      </h2>
+      <div className="aspect-[16/10] w-full overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-800">
+        {src ? (
+          <iframe
+            title={title}
+            src={src}
+            loading="lazy"
+            className="h-[70vh] w-full sm:h-[75vh]"
+            referrerPolicy="no-referrer-when-downgrade"
+            sandbox="allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts"
+          />
+        ) : (
+          <div className="flex h-[70vh] w-full items-center justify-center text-sm opacity-70 sm:h-[75vh]">Loading…</div>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef } from "react";
+
+type ModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  titleId?: string;
+  children: React.ReactNode;
+};
+
+export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, titleId = "modal-title", children }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const last = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    if (isOpen) {
+      last.current = document.activeElement as HTMLElement | null;
+      document.addEventListener("keydown", onKey);
+      document.body.style.overflow = "hidden";
+      setTimeout(() => ref.current?.focus(), 0);
+    }
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+      last.current?.focus?.();
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <div className="absolute inset-0 bg-black/60 dark:bg-black/70" onClick={onClose} />
+      <div
+        ref={ref}
+        tabIndex={-1}
+        className="relative mx-3 w-full max-w-5xl rounded-2xl bg-white text-black shadow-2xl outline-none dark:bg-neutral-900 dark:text-white"
+      >
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-4 top-4 rounded-xl border px-2 py-1 text-sm opacity-80 hover:opacity-100 dark:border-neutral-700"
+        >
+          ✕
+        </button>
+        <div className="p-4 sm:p-6">{children}</div>
+      </div>
+    </div>
+  );
+};

--- a/src/config/booking.ts
+++ b/src/config/booking.ts
@@ -1,0 +1,13 @@
+export const CALENDLY = {
+  fr: "https://calendly.com/krglobalsolutionsltd/30min",
+  en: "https://calendly.com/krglobalsolutionsltd/30-minute-meeting-clone",
+  /**
+   * Sélecteur CSS optionnel pour cibler le bouton de la DERNIÈRE CARD (Pack Sur‑mesure)
+   * afin d'ouvrir le MODAL au lieu d'un nouvel onglet.
+   * 
+   * Exemples possibles (n'en garder qu'UN, ajuste si tu as un data-attr) :
+   * - '[data-pack="surmesure"] [data-calendly="30min"]'
+   * - '.pricing-grid .card:last-of-type [data-calendly="30min"]'
+   */
+  modalTargetSelector: '.pricing-grid .card:last-of-type [data-calendly="30min"]',
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,11 @@ import App from './App.tsx';
 import LegalPage from './app/mentions-legales/page.tsx';
 import BookPage from './app/book/page.tsx';
 import './index.css';
+import { attachCalendlyEnhancer } from './bookingEnhancer';
+
+interface CalendlyWindow extends Window {
+  __calendlyEnhancerLoaded?: boolean;
+}
 
 const rootElement = document.getElementById('root')!;
 
@@ -16,3 +21,10 @@ createRoot(rootElement).render(
         : <App />}
   </StrictMode>,
 );
+
+const w = window as CalendlyWindow;
+if (!w.__calendlyEnhancerLoaded) {
+  w.__calendlyEnhancerLoaded = true;
+  // Lance une seule fois
+  requestAnimationFrame(() => attachCalendlyEnhancer());
+}

--- a/src/utils/lang.ts
+++ b/src/utils/lang.ts
@@ -1,0 +1,12 @@
+export function getCurrentLang(): "fr" | "en" {
+  try {
+    const ls = (typeof window !== "undefined" && localStorage.getItem("lang")) as "fr" | "en" | null;
+    const html = (typeof document !== "undefined" && document.documentElement.getAttribute("lang")) as
+      | "fr"
+      | "en"
+      | null;
+    return (ls || html || "fr") === "en" ? "en" : "fr";
+  } catch {
+    return "fr";
+  }
+}

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,12 @@
+export function setPageSEO(title?: string, description?: string) {
+  if (title) document.title = title;
+  if (description) {
+    let meta = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = "description";
+      document.head.appendChild(meta);
+    }
+    meta.content = description;
+  }
+}


### PR DESCRIPTION
## Summary
- add CALENDLY configuration and language/SEO utilities
- implement accessible modal and Calendly embed component
- hook booking enhancer into main entry once

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689eb2154d0c8331b8521e189bee5bd3