### PR TITLE
Add Calendly booking modal and translations

### DIFF
--- a/src/bookingEnhancer.ts
+++ b/src/bookingEnhancer.ts
@@ -5,6 +5,9 @@ import { createRoot } from "react-dom/client";
 import { CalendlyEmbed } from "./components/booking/CalendlyEmbed";
 
 type BoundHTMLElement = HTMLElement & { __calendlyBound?: boolean };
+interface CalendlyWindow extends Window {
+  __calendlyEnhancerLoaded?: boolean;
+}
 
 function openInNewTab(url: string) {
   window.open(url, "_blank", "noopener,noreferrer");
@@ -61,6 +64,10 @@ function bindNode(el: BoundHTMLElement, mode: "tab" | "modal", url: string, lang
 }
 
 export function attachCalendlyEnhancer() {
+  const w = window as CalendlyWindow;
+  if (w.__calendlyEnhancerLoaded) return;
+  w.__calendlyEnhancerLoaded = true;
+
   const lang = getCurrentLang();
   const url = lang === "en" ? CALENDLY.en : CALENDLY.fr;
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,7 @@
+{
+  "booking": {
+    "title": "Book 30 minutes",
+    "description": "Book a slot without leaving the site.",
+    "cta": "Book 30 min"
+  }
+}

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,0 +1,7 @@
+{
+  "booking": {
+    "title": "Réserver 30 minutes",
+    "description": "Réservez un créneau sans quitter le site.",
+    "cta": "Réserver 30 min"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,10 +6,6 @@ import BookPage from './app/book/page.tsx';
 import './index.css';
 import { attachCalendlyEnhancer } from './bookingEnhancer';
 
-interface CalendlyWindow extends Window {
-  __calendlyEnhancerLoaded?: boolean;
-}
-
 const rootElement = document.getElementById('root')!;
 
 createRoot(rootElement).render(
@@ -22,9 +18,4 @@ createRoot(rootElement).render(
   </StrictMode>,
 );
 
-const w = window as CalendlyWindow;
-if (!w.__calendlyEnhancerLoaded) {
-  w.__calendlyEnhancerLoaded = true;
-  // Lance une seule fois
-  requestAnimationFrame(() => attachCalendlyEnhancer());
-}
+requestAnimationFrame(() => attachCalendlyEnhancer());


### PR DESCRIPTION
## Summary
- prevent multiple Calendly enhancer loads by tracking a window flag
- initialize Calendly enhancer from main entrypoint
- add booking translation strings for English and French

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "next/link")*

------
https://chatgpt.com/codex/tasks/task_b_689eb90ca92483318a3db7f6140a16aa