### PR TITLE
Add booking modal with context and translated buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@ import { Footer } from './components/Footer';
 import OffersSection from '@/components/OffersSection';
 import QuizPack from '@/components/pricing/QuizPack';
 import { ENABLE_DZ_PARTICLES, SHOW_PRICING } from './featureFlags';
-import CalendlyLoader from '@/app/_components/CalendlyLoader';
 
 const DarkZoneParticles = React.lazy(() => import('./components/DarkZoneParticles'));
 // FAQ (lazy universel)
@@ -35,7 +34,6 @@ function App() {
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
     >
-      <CalendlyLoader />
       <Header
         currentLanguage={currentLanguage}
         onLanguageChange={changeLanguage}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import CalendlyButton from '@/components/CalendlyButton';
+import { useBooking } from '@/context/BookingContext';
+import { useTranslation } from 'react-i18next';
 import { Translation } from '../data/translations';
 
 interface ContactProps {
@@ -7,12 +8,16 @@ interface ContactProps {
 }
 
 export default function Contact({ t }: ContactProps) {
+  const { openBooking } = useBooking();
+  const { t: tI18n } = useTranslation();
   return (
     <section className="py-10">
       <h2 className="text-2xl font-semibold">{t.contact.title}</h2>
-      <div className="mt-6">
-        <CalendlyButton />
-      </div>
+        <div className="mt-6">
+          <button className="btn-primary" onClick={openBooking}>
+            {tI18n('booking.buttonCall')}
+          </button>
+        </div>
     </section>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import SocialLinks from '@/components/SocialLinks';
-import CalendlyButton from "@/components/CalendlyButton";
+import { useBooking } from '@/context/BookingContext';
+import { useTranslation } from 'react-i18next';
 
 export function Footer() {
+  const { openBooking } = useBooking();
+  const { t } = useTranslation();
   const pathname =
     typeof window !== 'undefined' ? window.location.pathname : '';
   const prefix = pathname.startsWith('/en') ? '/en' : '';
@@ -30,10 +33,12 @@ export function Footer() {
             ))}
           </ul>
         </div>
-        <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
-          <SocialLinks variant="footer" size={22} className="justify-center sm:justify-end" />
-          <CalendlyButton className="mt-4" />
-        </div>
+          <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
+            <SocialLinks variant="footer" size={22} className="justify-center sm:justify-end" />
+            <button className="btn-primary mt-4" onClick={openBooking}>
+              {t('booking.buttonCall')}
+            </button>
+          </div>
       </div>
     </footer>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,17 +5,20 @@ import { Language, Translation } from '../data/translations';
 import KRLogoKR from "@/components/KRLogoKR";
 import { DarkZoneToggle } from './DarkZoneToggle';
 import { Menu, X } from "lucide-react";
-import CalendlyButton from "@/components/CalendlyButton";
+import { useBooking } from "@/context/BookingContext";
+import { useTranslation } from "react-i18next";
 
-interface HeaderProps {
-  currentLanguage: Language;
-  onLanguageChange: (lang: Language) => void;
-  t: Translation;
-}
+  interface HeaderProps {
+    currentLanguage: Language;
+    onLanguageChange: (lang: Language) => void;
+    t: Translation;
+  }
 
-export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
-  const [open, setOpen] = React.useState(false);
-  return (
+  export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
+    const { openBooking } = useBooking();
+    const { t: tI18n } = useTranslation();
+    const [open, setOpen] = React.useState(false);
+    return (
     <header className="sticky top-0 z-[100] bg-white/80 backdrop-blur-md border-b border-neutral-200 dz-card dz-border dz-fg">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 h-16 flex items-center justify-between">
         <div className="flex items-center gap-3 min-w-0">
@@ -33,7 +36,12 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
           <DarkZoneToggle label={t.nav.darkZone} />
         </div>
         <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
-          <CalendlyButton className="ml-4 hidden sm:inline-flex text-sm" />
+            <button
+              className="btn-primary ml-4 hidden sm:inline-flex text-sm"
+              onClick={openBooking}
+            >
+              {tI18n("booking.buttonCall")}
+            </button>
           <SocialLinks variant="header" size={20} className="justify-end hidden md:flex" />
           <button
             className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50"

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,14 +4,17 @@ import { motion } from 'framer-motion';
 import InfiniteHeadline from '@/components/InfiniteHeadline';
 import { Translation } from '../data/translations';
 import HeroVideoCompat from '@/components/HeroVideoCompat';
-import CalendlyButton from '@/app/_components/CalendlyButton';
+import { useBooking } from '@/context/BookingContext';
+import { useTranslation } from 'react-i18next';
 
-interface HeroSectionProps {
-  t: Translation;
-}
+  interface HeroSectionProps {
+    t: Translation;
+  }
 
-export function HeroSection({ t }: HeroSectionProps) {
-  return (
+  export function HeroSection({ t }: HeroSectionProps) {
+    const { openBooking } = useBooking();
+    const { t: tI18n } = useTranslation();
+    return (
     <section className="flex items-center justify-center py-10 sm:py-20 bg-gradient-to-br from-white to-neutral-50 dz-bg dz-fg md:min-h-screen">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 text-center">
         {/* Title and Subtitle */}
@@ -30,9 +33,11 @@ export function HeroSection({ t }: HeroSectionProps) {
           <div className="mt-6 md:mt-8">
             <HeroVideoCompat />
           </div>
-          <div className="mt-6">
-            <CalendlyButton />
-          </div>
+            <div className="mt-6">
+              <button className="btn-primary" onClick={openBooking}>
+                {tI18n("booking.button30")}
+              </button>
+            </div>
         </motion.div>
       </div>
     </section>

--- a/src/components/OffersSection.tsx
+++ b/src/components/OffersSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
+import { useBooking } from "@/context/BookingContext";
 import { Link } from "react-router-dom";
 
 /** Types locaux (évite les imports qui cassent le build) */
@@ -251,6 +252,7 @@ const tf = (key: string) => {
 };
 
 export default function OffersSection() {
+  const { openBooking } = useBooking();
   const [packs, setPacks] = useState<Pack[]>(PACKS_FALLBACK);
 
   useEffect(() => {
@@ -360,16 +362,16 @@ export default function OffersSection() {
                   <span className="btn-txt">{tf(p.ctas.primary.labelKey)}</span>
                 </a>
                 {p.ctas.secondary && (
-                    <a
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        window.openCalendly?.("popup");
-                      }}
-                      className="rounded-2xl border px-4 py-2 text-sm"
-                    >
-                      {tf(p.ctas.secondary.labelKey)}
-                    </a>
+                      <a
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          openBooking();
+                        }}
+                        className="rounded-2xl border px-4 py-2 text-sm"
+                      >
+                        {tf(p.ctas.secondary.labelKey)}
+                      </a>
                   )}
                 {p.ctas.whatsapp && (
                   <a

--- a/src/context/BookingContext.tsx
+++ b/src/context/BookingContext.tsx
@@ -1,0 +1,118 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { buildCalendlyEmbedUrl } from "../lib/booking";
+
+type BookingContextType = {
+  isOpen: boolean;
+  openBooking: () => void;
+  closeBooking: () => void;
+};
+
+const BookingContext = createContext<BookingContextType | null>(null);
+
+export const useBooking = () => {
+  const ctx = useContext(BookingContext);
+  if (!ctx) throw new Error("useBooking must be used within BookingProvider");
+  return ctx;
+};
+
+function useLockBodyScroll(active: boolean) {
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = active ? "hidden" : prev;
+    return () => { document.body.style.overflow = prev; };
+  }, [active]);
+}
+
+function useFocusTrap(active: boolean, containerRef: React.RefObject<HTMLDivElement>) {
+  useEffect(() => {
+    if (!active || !containerRef.current) return;
+    const container = containerRef.current;
+    const focusable = container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Tab") {
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault(); (last || first).focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault(); (first || last).focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    (first || container).focus();
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [active, containerRef]);
+}
+
+export const BookingProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [isOpen, setOpen] = useState(false);
+  const openBooking = useCallback(() => setOpen(true), []);
+  const closeBooking = useCallback(() => setOpen(false), []);
+
+  return (
+    <BookingContext.Provider value={{ isOpen, openBooking, closeBooking }}>
+      {children}
+      <BookingModal />
+    </BookingContext.Provider>
+  );
+};
+
+const BookingModal: React.FC = () => {
+  const { t } = useTranslation();
+  const { isOpen, closeBooking } = useBooking();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useLockBodyScroll(isOpen);
+  useFocusTrap(isOpen, containerRef);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeBooking();
+    };
+    if (isOpen) document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, closeBooking]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="booking-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="booking-title"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) closeBooking();
+      }}
+    >
+      <div className="booking-modal" ref={containerRef} tabIndex={-1}>
+        <div className="booking-header">
+          <div id="booking-title" className="booking-title">
+            {t("booking.title")}
+          </div>
+          <button
+            type="button"
+            aria-label={t("booking.close")}
+            className="booking-close"
+            onClick={closeBooking}
+          >
+            ×
+          </button>
+        </div>
+        <div className="booking-content">
+          <iframe
+            className="booking-iframe"
+            title={t("booking.iframeTitle")}
+            src={buildCalendlyEmbedUrl()}
+            allow="payment *; microphone *; camera *; clipboard-read *; clipboard-write *;"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,7 +1,10 @@
 {
   "booking": {
-    "title": "Book 30 minutes",
-    "description": "Book a slot without leaving the site.",
-    "cta": "Book 30 min"
+    "title": "Book a Call (30 min)",
+    "close": "Close calendar",
+    "iframeTitle": "Calendly - Scheduling",
+    "buttonCall": "Book a Call",
+    "button30": "Book 30 minutes",
+    "buttonBook": "Book Now"
   }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,7 +1,10 @@
 {
   "booking": {
-    "title": "Réserver 30 minutes",
-    "description": "Réservez un créneau sans quitter le site.",
-    "cta": "Réserver 30 min"
+    "title": "Réserver un appel (30 min)",
+    "close": "Fermer le calendrier",
+    "iframeTitle": "Calendly - Planification",
+    "buttonCall": "Réserver un appel",
+    "button30": "Réserver 30 minutes",
+    "buttonBook": "Réserver"
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 @import './styles/globals.css';
+@import './styles/booking.css';
 
 @tailwind base;
 @tailwind components;

--- a/src/lib/booking.ts
+++ b/src/lib/booking.ts
@@ -1,0 +1,11 @@
+export const CALENDLY_BASE =
+  "https://calendly.com/krglobalsolutionsltd/30-minute-meeting-clone";
+
+export function buildCalendlyEmbedUrl(): string {
+  const host = typeof window !== "undefined" && window.location?.hostname
+    ? window.location.hostname
+    : "krglobalsolutionsltd.com";
+
+  const params = new URLSearchParams({ embed_domain: host });
+  return `${CALENDLY_BASE}?${params.toString()}`;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
-import { attachCalendlyEnhancer } from './bookingEnhancer';
+import { BookingProvider } from './context/BookingContext';
 
 // IMPORTANT : charger l'initialisation i18n AVANT tout hook/useTranslation
 import './i18n';
@@ -21,15 +21,15 @@ if (!rootEl) {
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
     <BrowserRouter basename={import.meta.env.BASE_URL}>
-      {/* 
+      {/*
       // Si tu veux forcer le provider explicite :
       <I18nextProvider i18n={i18n}>
         <App />
       </I18nextProvider>
       */}
-      <App />
+      <BookingProvider>
+        <App />
+      </BookingProvider>
     </BrowserRouter>
   </React.StrictMode>
 );
-
-requestAnimationFrame(() => attachCalendlyEnhancer());

--- a/src/styles/booking.css
+++ b/src/styles/booking.css
@@ -1,0 +1,113 @@
+/* Thème blanc permanent et styles bouton/Modal */
+:root {
+  --bg: #ffffff;
+  --text: #111111;
+  --muted: #666666;
+  --border: #111111;
+  --backdrop: rgba(0, 0, 0, 0.55);
+  --btn-bg: #ffffff;
+  --btn-text: #111111;
+  --btn-border: #111111;
+  --btn-bg-hover: #f5f5f5;
+  --focus: #111111;
+}
+
+html, body, #root {
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100%;
+}
+
+button.btn-primary,
+a.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .75rem 1rem;
+  font-weight: 600;
+  border: 1.5px solid var(--btn-border);
+  background: var(--btn-bg);
+  color: var(--btn-text);
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: background .2s ease, transform .02s ease;
+  text-decoration: none;
+}
+button.btn-primary:hover,
+a.btn-primary:hover {
+  background: var(--btn-bg-hover);
+}
+button.btn-primary:active,
+a.btn-primary:active {
+  transform: translateY(1px);
+}
+button.btn-primary:focus-visible,
+a.btn-primary:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+/* Modal */
+.booking-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--backdrop);
+  display: grid;
+  place-items: center;
+  z-index: 9999;
+}
+
+.booking-modal {
+  background: #fff;
+  color: #111;
+  width: min(1000px, 92vw);
+  height: min(80vh, 880px);
+  border-radius: 16px;
+  box-shadow: 0 20px 70px rgba(0,0,0,.35);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.booking-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: .75rem 1rem;
+  border-bottom: 1px solid #eaeaea;
+}
+.booking-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+.booking-close {
+  appearance: none;
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #333;
+}
+.booking-close:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.booking-content {
+  flex: 1;
+  position: relative;
+}
+.booking-iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+/* Cacher reliquats dark-mode */
+[class*="dark"], [data-theme="dark"] {
+  background: var(--bg) !important;
+  color: var(--text) !important;
+}
+


### PR DESCRIPTION
## Summary
- add `BookingProvider` with modal-based Calendly embed
- replace existing Calendly buttons with booking context hooks
- introduce translations and styling for booking modal and buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689ee755f07c8331b41bb4f6f5bdd5b7