### PR TITLE
fix: suppression noms/tags/adresse + réparation Calendly

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
     <!-- Preconnect to external domains for performance -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Calendly popup widget -->
+    <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">
+    <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@react-three/fiber": "^8.17.14",
         "@types/node": "^24.2.1",
+        "@types/three": "^0.168.0",
         "clsx": "^2.1.0",
         "framer-motion": "^10.16.16",
         "i18next": "^23.16.8",
@@ -18,6 +20,7 @@
         "react-i18next": "^14.1.3",
         "react-icons": "^4.11.0",
         "react-router-dom": "^7.8.0",
+        "three": "^0.168.0",
         "three-stdlib": "^2.36.0",
         "tslib": "^2.8.1"
       },
@@ -1279,6 +1282,64 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-three/fiber": {
+      "version": "8.17.14",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.17.14.tgz",
+      "integrity": "sha512-Al2Zdhn5vRefK0adJXNDputuM8hwRNh3goH8MCzf06gezZBbEsdmjt5IrHQQ8Rpr7l/znx/ipLUQuhiiVhxifQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1566,6 +1627,12 @@
         "win32"
       ]
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1650,14 +1717,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1673,6 +1738,41 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.168.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.168.0.tgz",
+      "integrity": "sha512-qAGLGzbaYgkkonOBfwOr+TZpOskPfFjrDAj801WQSVkUz0/D9zwir4vhruJ/CC/GteywzR9pqeVVfs5th/2oKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/three/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/@types/webxr": {
       "version": "0.5.22",
@@ -1972,6 +2072,12 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
+      "integrity": "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2131,6 +2237,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2199,6 +2325,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/callsites": {
@@ -2405,7 +2555,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3174,6 +3323,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3296,6 +3465,27 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3536,6 +3726,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4100,6 +4296,31 @@
         "react": "*"
       }
     },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4146,6 +4367,21 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -4551,6 +4787,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -4620,11 +4865,10 @@
       }
     },
     "node_modules/three": {
-      "version": "0.179.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
-      "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
-      "license": "MIT",
-      "peer": true
+      "version": "0.168.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
+      "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw==",
+      "license": "MIT"
     },
     "node_modules/three-stdlib": {
       "version": "2.36.0",
@@ -5603,6 +5847,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "codex:fix-deploy": "tsx scripts/fix-deploy.ts"
   },
   "dependencies": {
+    "@react-three/fiber": "^8.17.14",
     "@types/node": "^24.2.1",
+    "@types/three": "^0.168.0",
     "clsx": "^2.1.0",
     "framer-motion": "^10.16.16",
     "i18next": "^23.16.8",
@@ -24,6 +26,7 @@
     "react-i18next": "^14.1.3",
     "react-icons": "^4.11.0",
     "react-router-dom": "^7.8.0",
+    "three": "^0.168.0",
     "three-stdlib": "^2.36.0",
     "tslib": "^2.8.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
   const { currentLanguage, changeLanguage, t } = useLanguage();
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-black">
       <Header
         currentLanguage={currentLanguage}
         onLanguageChange={changeLanguage}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,62 +1,27 @@
-import React, { Suspense } from 'react';
-import { motion } from 'framer-motion';
 import { useLanguage } from './hooks/useLanguage';
 import { Header } from './components/Header';
-import { HeroSection } from './components/HeroSection';
-import { AboutSection } from './components/AboutSection';
 import { Footer } from './components/Footer';
-import OffersSection from '@/components/OffersSection';
-import QuizPack from '@/components/pricing/QuizPack';
-import { ENABLE_DZ_PARTICLES, SHOW_PRICING } from './featureFlags';
-
-const DarkZoneParticles = React.lazy(() => import('./components/DarkZoneParticles'));
-// FAQ (lazy universel)
-const FAQAccordion = React.lazy(() => import('@/components/faq/FAQAccordion'));
+import HeroNew from './components/HeroNew';
+import ProjectsSection from './components/ProjectsSection';
+import ContactSection from './components/ContactSection';
 
 function App() {
-  const { currentLanguage, changeLanguage, t, isRTL } = useLanguage();
-  const [showParticles, setShowParticles] = React.useState(false);
-
-  React.useEffect(() => {
-    if (!ENABLE_DZ_PARTICLES) return;
-    const body = document.body;
-    const update = () => setShowParticles(body.classList.contains('dark-zone'));
-    const observer = new MutationObserver(update);
-    observer.observe(body, { attributes: true, attributeFilter: ['class'] });
-    update();
-    return () => observer.disconnect();
-  }, []);
+  const { currentLanguage, changeLanguage, t } = useLanguage();
 
   return (
-    <motion.div
-      className="flex min-h-screen flex-col bg-white dz-bg dz-fg"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.5 }}
-    >
+    <div className="flex min-h-screen flex-col bg-white">
       <Header
         currentLanguage={currentLanguage}
         onLanguageChange={changeLanguage}
         t={t}
       />
-
       <main className="flex-1">
-        <HeroSection t={t} />
-        <OffersSection />
-        {SHOW_PRICING && <QuizPack />}
-        {/* ===== Section FAQ ===== */}
-        <Suspense fallback={null}>
-          <FAQAccordion />
-        </Suspense>
-        <AboutSection t={t} isRTL={isRTL} />
+        <HeroNew lang={currentLanguage} />
+        <ProjectsSection lang={currentLanguage} />
+        <ContactSection lang={currentLanguage} />
       </main>
       <Footer />
-      {ENABLE_DZ_PARTICLES && showParticles && (
-        <Suspense fallback={null}>
-          <DarkZoneParticles />
-        </Suspense>
-      )}
-    </motion.div>
+    </div>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,9 +20,9 @@ function MainPage() {
       <HeroNew lang={currentLanguage} />
       <CompanySection lang={currentLanguage} />
       <ProjectsSection lang={currentLanguage} />
-      <section id="faq" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
+      <section id="faq" className="py-24 sm:py-32 bg-white border-t border-black/[0.06]">
         <div className="container mx-auto px-4 sm:px-6 md:px-8">
-          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-600 mb-12">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-400 mb-12">
             {faqLabel}
           </p>
           <Suspense fallback={null}>
@@ -39,7 +39,7 @@ function App() {
   const { currentLanguage, changeLanguage, t } = useLanguage();
 
   return (
-    <div className="flex min-h-screen flex-col bg-black">
+    <div className="flex min-h-screen flex-col bg-white">
       <Header
         currentLanguage={currentLanguage}
         onLanguageChange={changeLanguage}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,54 @@
+import { Suspense, lazy } from 'react';
+import { Routes, Route } from 'react-router-dom';
 import { useLanguage } from './hooks/useLanguage';
 import { Header } from './components/Header';
 import { Footer } from './components/Footer';
 import HeroNew from './components/HeroNew';
 import ProjectsSection from './components/ProjectsSection';
 import ContactSection from './components/ContactSection';
+import CompanySection from './components/CompanySection';
+import LegalPage from './app/mentions-legales/page';
+
+const FAQAccordion = lazy(() => import('@/components/faq/FAQAccordion'));
+
+function MainPage() {
+  const { currentLanguage, t } = useLanguage();
+  return (
+    <>
+      <HeroNew lang={currentLanguage} />
+      <CompanySection lang={currentLanguage} />
+      <ProjectsSection lang={currentLanguage} />
+      <Suspense fallback={null}>
+        <section id="faq" className="py-24 sm:py-32 border-t border-neutral-100 bg-white">
+          <div className="container mx-auto px-4 sm:px-6 md:px-8">
+            <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-400 mb-12">
+              {currentLanguage === 'fr' ? 'Questions fréquentes' : 'FAQ'}
+            </p>
+            <FAQAccordion locale={currentLanguage} />
+          </div>
+        </section>
+      </Suspense>
+      <ContactSection lang={currentLanguage} />
+    </>
+  );
+}
 
 function App() {
   const { currentLanguage, changeLanguage, t } = useLanguage();
 
   return (
-    <div className="flex min-h-screen flex-col bg-black">
+    <div className="flex min-h-screen flex-col bg-white">
       <Header
         currentLanguage={currentLanguage}
         onLanguageChange={changeLanguage}
         t={t}
       />
       <main className="flex-1">
-        <HeroNew lang={currentLanguage} />
-        <ProjectsSection lang={currentLanguage} />
-        <ContactSection lang={currentLanguage} />
+        <Routes>
+          <Route index element={<MainPage />} />
+          <Route path="mentions-legales" element={<LegalPage />} />
+          <Route path="en/mentions-legales" element={<LegalPage />} />
+        </Routes>
       </main>
       <Footer />
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,22 +12,24 @@ import LegalPage from './app/mentions-legales/page';
 const FAQAccordion = lazy(() => import('@/components/faq/FAQAccordion'));
 
 function MainPage() {
-  const { currentLanguage, t } = useLanguage();
+  const { currentLanguage } = useLanguage();
+  const faqLabel = currentLanguage === 'fr' ? 'Questions fréquentes' : 'FAQ';
+
   return (
     <>
       <HeroNew lang={currentLanguage} />
       <CompanySection lang={currentLanguage} />
       <ProjectsSection lang={currentLanguage} />
-      <Suspense fallback={null}>
-        <section id="faq" className="py-24 sm:py-32 border-t border-neutral-100 bg-white">
-          <div className="container mx-auto px-4 sm:px-6 md:px-8">
-            <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-400 mb-12">
-              {currentLanguage === 'fr' ? 'Questions fréquentes' : 'FAQ'}
-            </p>
+      <section id="faq" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
+        <div className="container mx-auto px-4 sm:px-6 md:px-8">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-600 mb-12">
+            {faqLabel}
+          </p>
+          <Suspense fallback={null}>
             <FAQAccordion locale={currentLanguage} />
-          </div>
-        </section>
-      </Suspense>
+          </Suspense>
+        </div>
+      </section>
       <ContactSection lang={currentLanguage} />
     </>
   );
@@ -37,7 +39,7 @@ function App() {
   const { currentLanguage, changeLanguage, t } = useLanguage();
 
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="flex min-h-screen flex-col bg-black">
       <Header
         currentLanguage={currentLanguage}
         onLanguageChange={changeLanguage}

--- a/src/app/mentions-legales/page.tsx
+++ b/src/app/mentions-legales/page.tsx
@@ -4,10 +4,10 @@ import { useLanguage } from '@/hooks/useLanguage';
 function LegalFR() {
   return (
     <>
-      <h1 className="text-3xl font-bold text-white mb-10">Mentions légales</h1>
+      <h1 className="text-3xl font-bold text-black mb-10">Mentions légales</h1>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">1. Éditeur du site</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">1. Éditeur du site</h2>
         <p>Raison sociale : <strong>KR GLOBAL SOLUTIONS LTD</strong></p>
         <p>Forme juridique : Private Limited Company (Angleterre &amp; Pays de Galles)</p>
         <p>Numéro d'immatriculation (Companies House) : <strong>16517532</strong></p>
@@ -16,20 +16,20 @@ function LegalFR() {
         <p>Activités (codes SIC) : 46190 · 47910 · 62012 · 62090</p>
         <p>
           E-mail :{' '}
-          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-black/60 hover:text-black underline">
             contact@krglobalsolutionsltd.com
           </a>
         </p>
         <p>
           Site web :{' '}
-          <a href="https://krglobalsolutionsltd.com" target="_blank" rel="noopener noreferrer" className="text-white/70 hover:text-white underline">
+          <a href="https://krglobalsolutionsltd.com" target="_blank" rel="noopener noreferrer" className="text-black/60 hover:text-black underline">
             https://krglobalsolutionsltd.com
           </a>
         </p>
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">2. Hébergement</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">2. Hébergement</h2>
         <p>
           Ce site est hébergé sur une infrastructure cloud professionnelle. L'hébergeur met en œuvre
           les mesures techniques nécessaires pour assurer la continuité de service et la sécurité des
@@ -38,7 +38,7 @@ function LegalFR() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">3. Propriété intellectuelle</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">3. Propriété intellectuelle</h2>
         <p>
           L'ensemble des contenus présents sur ce site (textes, images, visuels, code source,
           logotypes) sont la propriété exclusive de KR GLOBAL SOLUTIONS LTD ou de ses concédants de
@@ -48,7 +48,7 @@ function LegalFR() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">4. Limitation de responsabilité</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">4. Limitation de responsabilité</h2>
         <p>
           KR GLOBAL SOLUTIONS LTD s'efforce d'assurer l'exactitude et la mise à jour des informations
           diffusées sur ce site. Toutefois, elle ne peut garantir l'exactitude, l'exhaustivité ou
@@ -58,7 +58,7 @@ function LegalFR() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">5. Liens hypertextes</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">5. Liens hypertextes</h2>
         <p>
           Ce site peut contenir des liens vers des sites tiers. Ces liens sont fournis à titre
           informatif uniquement. KR GLOBAL SOLUTIONS LTD n'exerce aucun contrôle sur ces sites et
@@ -68,7 +68,7 @@ function LegalFR() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">6. Données personnelles &amp; cookies</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">6. Données personnelles &amp; cookies</h2>
         <p>
           KR GLOBAL SOLUTIONS LTD collecte uniquement les données strictement nécessaires au bon
           fonctionnement du site et au traitement des demandes de contact. Ces données ne sont pas
@@ -76,7 +76,7 @@ function LegalFR() {
           Protection des Données (RGPD – Règlement UE 2016/679) et au UK GDPR, vous disposez d'un
           droit d'accès, de rectification, de suppression et de portabilité de vos données. Pour
           exercer ces droits, contactez-nous à{' '}
-          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-black/60 hover:text-black underline">
             contact@krglobalsolutionsltd.com
           </a>.
         </p>
@@ -88,7 +88,7 @@ function LegalFR() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">7. Droit applicable</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">7. Droit applicable</h2>
         <p>
           Le présent site et ses mentions légales sont soumis au droit anglais (England &amp; Wales).
           Tout litige relatif à l'utilisation de ce site sera soumis à la compétence exclusive des
@@ -97,11 +97,11 @@ function LegalFR() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">8. Contact</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">8. Contact</h2>
         <p>
           Pour toute question relative aux présentes mentions légales ou à l'utilisation de vos
           données personnelles, contactez-nous :{' '}
-          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-black/60 hover:text-black underline">
             contact@krglobalsolutionsltd.com
           </a>
         </p>
@@ -113,10 +113,10 @@ function LegalFR() {
 function LegalEN() {
   return (
     <>
-      <h1 className="text-3xl font-bold text-white mb-10">Legal Notice</h1>
+      <h1 className="text-3xl font-bold text-black mb-10">Legal Notice</h1>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">1. Publisher</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">1. Publisher</h2>
         <p>Company name: <strong>KR GLOBAL SOLUTIONS LTD</strong></p>
         <p>Legal form: Private Limited Company (England &amp; Wales)</p>
         <p>Companies House registration number: <strong>16517532</strong></p>
@@ -125,20 +125,20 @@ function LegalEN() {
         <p>Business activities (SIC codes): 46190 · 47910 · 62012 · 62090</p>
         <p>
           Email:{' '}
-          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-black/60 hover:text-black underline">
             contact@krglobalsolutionsltd.com
           </a>
         </p>
         <p>
           Website:{' '}
-          <a href="https://krglobalsolutionsltd.com" target="_blank" rel="noopener noreferrer" className="text-white/70 hover:text-white underline">
+          <a href="https://krglobalsolutionsltd.com" target="_blank" rel="noopener noreferrer" className="text-black/60 hover:text-black underline">
             https://krglobalsolutionsltd.com
           </a>
         </p>
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">2. Hosting</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">2. Hosting</h2>
         <p>
           This website is hosted on professional cloud infrastructure. The hosting provider implements
           the technical measures necessary to ensure service continuity and data security in accordance
@@ -147,7 +147,7 @@ function LegalEN() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">3. Intellectual Property</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">3. Intellectual Property</h2>
         <p>
           All content on this website (text, images, visuals, source code, logos) is the exclusive
           property of KR GLOBAL SOLUTIONS LTD or its licensors. Any reproduction, representation,
@@ -157,7 +157,7 @@ function LegalEN() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">4. Limitation of Liability</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">4. Limitation of Liability</h2>
         <p>
           KR GLOBAL SOLUTIONS LTD endeavours to ensure the accuracy and currency of the information
           published on this website. However, it cannot guarantee the accuracy, completeness or
@@ -167,7 +167,7 @@ function LegalEN() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">5. External Links</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">5. External Links</h2>
         <p>
           This website may contain links to third-party websites. These links are provided for
           informational purposes only. KR GLOBAL SOLUTIONS LTD has no control over those websites and
@@ -176,14 +176,14 @@ function LegalEN() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">6. Personal Data &amp; Cookies</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">6. Personal Data &amp; Cookies</h2>
         <p>
           KR GLOBAL SOLUTIONS LTD collects only the data strictly necessary for the proper operation
           of the website and for processing contact requests. This data is not sold to third parties
           for commercial purposes. In accordance with the UK GDPR and the EU General Data Protection
           Regulation (Regulation 2016/679), you have the right to access, rectify, erase and port your
           personal data. To exercise these rights, contact us at{' '}
-          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-black/60 hover:text-black underline">
             contact@krglobalsolutionsltd.com
           </a>.
         </p>
@@ -194,7 +194,7 @@ function LegalEN() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">7. Governing Law</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">7. Governing Law</h2>
         <p>
           This website and its legal notice are governed by the laws of England and Wales. Any dispute
           relating to the use of this website shall be subject to the exclusive jurisdiction of the
@@ -203,11 +203,11 @@ function LegalEN() {
       </section>
 
       <section className="mb-10">
-        <h2 className="text-lg font-semibold text-white mb-4">8. Contact</h2>
+        <h2 className="text-lg font-semibold text-black mb-4">8. Contact</h2>
         <p>
           For any questions regarding this legal notice or the use of your personal data, please
           contact us at:{' '}
-          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-black/60 hover:text-black underline">
             contact@krglobalsolutionsltd.com
           </a>
         </p>
@@ -227,10 +227,10 @@ export default function LegalPage() {
   }, [currentLanguage]);
 
   return (
-    <div className="min-h-screen bg-black">
-      <main className="mx-auto max-w-3xl px-4 sm:px-6 py-16 text-sm text-neutral-400 leading-relaxed space-y-2">
+    <div className="min-h-screen bg-white">
+      <main className="mx-auto max-w-3xl px-4 sm:px-6 py-16 text-sm text-neutral-600 leading-relaxed space-y-2">
         {currentLanguage === 'fr' ? <LegalFR /> : <LegalEN />}
-        <p className="text-xs text-neutral-700 pt-8 border-t border-white/[0.06]">
+        <p className="text-xs text-neutral-400 pt-8 border-t border-black/[0.06]">
           {currentLanguage === 'fr'
             ? `Dernière mise à jour : mai 2025`
             : `Last updated: May 2025`}

--- a/src/app/mentions-legales/page.tsx
+++ b/src/app/mentions-legales/page.tsx
@@ -1,122 +1,239 @@
 import React, { useEffect } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
 
-export default function LegalPage() {
-  useEffect(() => {
-    document.title = 'Mentions légales – KR GLOBAL SOLUTIONS LTD';
-    const meta = document.querySelector('meta[name="description"]');
-    if (meta) {
-      meta.setAttribute('content', 'Informations légales de KR GLOBAL SOLUTIONS LTD');
-    }
-  }, []);
-
+function LegalFR() {
   return (
-    <div className="min-h-screen bg-white">
-      <main className="mx-auto max-w-3xl px-4 py-12 prose prose-invert dark:prose-invert">
-        <h1>Mentions légales</h1>
+    <>
+      <h1 className="text-3xl font-bold text-white mb-10">Mentions légales</h1>
 
-        <h2>🇫🇷 Version française</h2>
-        <p>Éditeur du site : KR GLOBAL SOLUTIONS LTD (Angleterre & Pays de Galles)</p>
-        <p>N° d’immatriculation (Companies House) : 16517532</p>
-        <p>Date d’immatriculation : 13 juin 2025</p>
-        <p>Siège social : 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ, UK</p>
-        <p>Activités (SIC) : 46190, 47910, 62012, 62090</p>
-        <p>Représentant légal : La direction de KR GLOBAL SOLUTIONS LTD</p>
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">1. Éditeur du site</h2>
+        <p>Raison sociale : <strong>KR GLOBAL SOLUTIONS LTD</strong></p>
+        <p>Forme juridique : Private Limited Company (Angleterre &amp; Pays de Galles)</p>
+        <p>Numéro d'immatriculation (Companies House) : <strong>16517532</strong></p>
+        <p>Date d'immatriculation : 13 juin 2025</p>
+        <p>Siège social : 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ, Royaume-Uni</p>
+        <p>Activités (codes SIC) : 46190 · 47910 · 62012 · 62090</p>
         <p>
-          E‑mail :{' '}
-          <a href="mailto:contact@krglobalsolutionsltd.com">contact@krglobalsolutionsltd.com</a>
+          E-mail :{' '}
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+            contact@krglobalsolutionsltd.com
+          </a>
         </p>
         <p>
-          Site :{' '}
-          <a
-            href="https://krglobalsolutionsltd.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          Site web :{' '}
+          <a href="https://krglobalsolutionsltd.com" target="_blank" rel="noopener noreferrer" className="text-white/70 hover:text-white underline">
             https://krglobalsolutionsltd.com
           </a>
         </p>
-        <h3>Hébergement</h3>
-        <p>
-          Le site est hébergé sur des infrastructures spécialisées. Toutes les données sont
-          stockées et traitées avec les soins nécessaires.
-        </p>
-        <h3>Propriété intellectuelle</h3>
-        <p>
-          Le contenu du site est protégé par les lois en vigueur sur la propriété intellectuelle.
-          Toute reproduction est interdite sans autorisation préalable.
-        </p>
-        <h3>Responsabilité</h3>
-        <p>
-          KR GLOBAL SOLUTIONS LTD ne peut être tenue responsable des dommages directs ou indirects
-          résultant de l'utilisation du site.
-        </p>
-        <h3>Liens externes</h3>
-        <p>
-          Les liens externes sont fournis à titre informatif. KR GLOBAL SOLUTIONS LTD n'assume
-          aucune responsabilité quant à leur contenu.
-        </p>
-        <h3>Données personnelles & cookies</h3>
-        <p>
-          Les données collectées sont utilisées uniquement pour assurer le bon fonctionnement du
-          site. Les cookies peuvent être utilisés à des fins de statistiques anonymes.
-        </p>
-        <h3>Contact</h3>
-        <p>
-          Pour toute question, veuillez nous contacter à l'adresse suivante :{' '}
-          <a href="mailto:contact@krglobalsolutionsltd.com">contact@krglobalsolutionsltd.com</a>.
-        </p>
+      </section>
 
-        <hr />
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">2. Hébergement</h2>
+        <p>
+          Ce site est hébergé sur une infrastructure cloud professionnelle. L'hébergeur met en œuvre
+          les mesures techniques nécessaires pour assurer la continuité de service et la sécurité des
+          données conformément aux pratiques du secteur.
+        </p>
+      </section>
 
-        <h2>🇬🇧 English version</h2>
-        <p>Website publisher: KR GLOBAL SOLUTIONS LTD (England & Wales)</p>
-        <p>Registration No. (Companies House): 16517532</p>
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">3. Propriété intellectuelle</h2>
+        <p>
+          L'ensemble des contenus présents sur ce site (textes, images, visuels, code source,
+          logotypes) sont la propriété exclusive de KR GLOBAL SOLUTIONS LTD ou de ses concédants de
+          licence. Toute reproduction, représentation, modification, publication ou adaptation, totale
+          ou partielle, est strictement interdite sans autorisation écrite préalable.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">4. Limitation de responsabilité</h2>
+        <p>
+          KR GLOBAL SOLUTIONS LTD s'efforce d'assurer l'exactitude et la mise à jour des informations
+          diffusées sur ce site. Toutefois, elle ne peut garantir l'exactitude, l'exhaustivité ou
+          l'actualité des informations, et décline toute responsabilité pour tout dommage direct ou
+          indirect résultant de l'accès au site ou de son utilisation.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">5. Liens hypertextes</h2>
+        <p>
+          Ce site peut contenir des liens vers des sites tiers. Ces liens sont fournis à titre
+          informatif uniquement. KR GLOBAL SOLUTIONS LTD n'exerce aucun contrôle sur ces sites et
+          décline toute responsabilité quant à leur contenu, leur disponibilité ou leur politique de
+          confidentialité.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">6. Données personnelles &amp; cookies</h2>
+        <p>
+          KR GLOBAL SOLUTIONS LTD collecte uniquement les données strictement nécessaires au bon
+          fonctionnement du site et au traitement des demandes de contact. Ces données ne sont pas
+          cédées à des tiers à des fins commerciales. Conformément au Règlement Général sur la
+          Protection des Données (RGPD – Règlement UE 2016/679) et au UK GDPR, vous disposez d'un
+          droit d'accès, de rectification, de suppression et de portabilité de vos données. Pour
+          exercer ces droits, contactez-nous à{' '}
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+            contact@krglobalsolutionsltd.com
+          </a>.
+        </p>
+        <p className="mt-3">
+          Des cookies techniques peuvent être utilisés à des fins de bon fonctionnement du site et de
+          statistiques anonymes. Aucun cookie publicitaire ou de traçage tiers n'est déposé sans votre
+          consentement explicite.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">7. Droit applicable</h2>
+        <p>
+          Le présent site et ses mentions légales sont soumis au droit anglais (England &amp; Wales).
+          Tout litige relatif à l'utilisation de ce site sera soumis à la compétence exclusive des
+          tribunaux anglais, sauf disposition légale contraire applicable au consommateur.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">8. Contact</h2>
+        <p>
+          Pour toute question relative aux présentes mentions légales ou à l'utilisation de vos
+          données personnelles, contactez-nous :{' '}
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+            contact@krglobalsolutionsltd.com
+          </a>
+        </p>
+      </section>
+    </>
+  );
+}
+
+function LegalEN() {
+  return (
+    <>
+      <h1 className="text-3xl font-bold text-white mb-10">Legal Notice</h1>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">1. Publisher</h2>
+        <p>Company name: <strong>KR GLOBAL SOLUTIONS LTD</strong></p>
+        <p>Legal form: Private Limited Company (England &amp; Wales)</p>
+        <p>Companies House registration number: <strong>16517532</strong></p>
         <p>Incorporation date: 13 June 2025</p>
-        <p>Registered office: 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ, UK</p>
-        <p>Business activities (SIC): 46190, 47910, 62012, 62090</p>
-        <p>Legal representative: The management of KR GLOBAL SOLUTIONS LTD</p>
+        <p>Registered office: 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ, United Kingdom</p>
+        <p>Business activities (SIC codes): 46190 · 47910 · 62012 · 62090</p>
         <p>
-          E‑mail: <a href="mailto:contact@krglobalsolutionsltd.com">contact@krglobalsolutionsltd.com</a>
+          Email:{' '}
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+            contact@krglobalsolutionsltd.com
+          </a>
         </p>
         <p>
           Website:{' '}
-          <a
-            href="https://krglobalsolutionsltd.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href="https://krglobalsolutionsltd.com" target="_blank" rel="noopener noreferrer" className="text-white/70 hover:text-white underline">
             https://krglobalsolutionsltd.com
           </a>
         </p>
-        <h3>Hosting</h3>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">2. Hosting</h2>
         <p>
-          The site is hosted on professional infrastructure. All data is stored and processed with
-          due care.
+          This website is hosted on professional cloud infrastructure. The hosting provider implements
+          the technical measures necessary to ensure service continuity and data security in accordance
+          with industry best practices.
         </p>
-        <h3>Intellectual property</h3>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">3. Intellectual Property</h2>
         <p>
-          The content of the site is protected by applicable intellectual property laws. Any
-          reproduction requires prior authorization.
+          All content on this website (text, images, visuals, source code, logos) is the exclusive
+          property of KR GLOBAL SOLUTIONS LTD or its licensors. Any reproduction, representation,
+          modification, publication or adaptation, in whole or in part, is strictly prohibited without
+          prior written authorisation.
         </p>
-        <h3>Liability</h3>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">4. Limitation of Liability</h2>
         <p>
-          KR GLOBAL SOLUTIONS LTD cannot be held liable for direct or indirect damages resulting
-          from the use of the site.
+          KR GLOBAL SOLUTIONS LTD endeavours to ensure the accuracy and currency of the information
+          published on this website. However, it cannot guarantee the accuracy, completeness or
+          timeliness of the information, and accepts no liability for any direct or indirect loss
+          arising from access to or use of the website.
         </p>
-        <h3>External links</h3>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">5. External Links</h2>
         <p>
-          External links are provided for convenience only. KR GLOBAL SOLUTIONS LTD does not
-          endorse or assume responsibility for their content.
+          This website may contain links to third-party websites. These links are provided for
+          informational purposes only. KR GLOBAL SOLUTIONS LTD has no control over those websites and
+          accepts no responsibility for their content, availability or privacy practices.
         </p>
-        <h3>Personal data & cookies</h3>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">6. Personal Data &amp; Cookies</h2>
         <p>
-          Data collected is used solely to ensure the proper functioning of the site. Cookies may be
-          used for anonymous statistical purposes.
+          KR GLOBAL SOLUTIONS LTD collects only the data strictly necessary for the proper operation
+          of the website and for processing contact requests. This data is not sold to third parties
+          for commercial purposes. In accordance with the UK GDPR and the EU General Data Protection
+          Regulation (Regulation 2016/679), you have the right to access, rectify, erase and port your
+          personal data. To exercise these rights, contact us at{' '}
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+            contact@krglobalsolutionsltd.com
+          </a>.
         </p>
-        <h3>Contact</h3>
+        <p className="mt-3">
+          Technical cookies may be used for proper website functioning and anonymous statistics. No
+          advertising or third-party tracking cookies are placed without your explicit consent.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">7. Governing Law</h2>
         <p>
-          For any inquiries, please contact us at:{' '}
-          <a href="mailto:contact@krglobalsolutionsltd.com">contact@krglobalsolutionsltd.com</a>.
+          This website and its legal notice are governed by the laws of England and Wales. Any dispute
+          relating to the use of this website shall be subject to the exclusive jurisdiction of the
+          English courts, unless mandatory consumer protection laws provide otherwise.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold text-white mb-4">8. Contact</h2>
+        <p>
+          For any questions regarding this legal notice or the use of your personal data, please
+          contact us at:{' '}
+          <a href="mailto:contact@krglobalsolutionsltd.com" className="text-white/70 hover:text-white underline">
+            contact@krglobalsolutionsltd.com
+          </a>
+        </p>
+      </section>
+    </>
+  );
+}
+
+export default function LegalPage() {
+  const { currentLanguage } = useLanguage();
+
+  useEffect(() => {
+    document.title =
+      currentLanguage === 'fr'
+        ? 'Mentions légales – KR GLOBAL SOLUTIONS LTD'
+        : 'Legal Notice – KR GLOBAL SOLUTIONS LTD';
+  }, [currentLanguage]);
+
+  return (
+    <div className="min-h-screen bg-black">
+      <main className="mx-auto max-w-3xl px-4 sm:px-6 py-16 text-sm text-neutral-400 leading-relaxed space-y-2">
+        {currentLanguage === 'fr' ? <LegalFR /> : <LegalEN />}
+        <p className="text-xs text-neutral-700 pt-8 border-t border-white/[0.06]">
+          {currentLanguage === 'fr'
+            ? `Dernière mise à jour : mai 2025`
+            : `Last updated: May 2025`}
         </p>
       </main>
     </div>

--- a/src/components/CompanySection.tsx
+++ b/src/components/CompanySection.tsx
@@ -36,16 +36,6 @@ export default function CompanySection({ lang }: { lang: Language }) {
             <p className="text-neutral-500 leading-relaxed text-base">
               {t.about.content}
             </p>
-
-            <div className="mt-8 text-sm">
-              <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-1">
-                {lang === 'fr' ? 'Siège social' : 'Registered office'}
-              </p>
-              <p className="text-neutral-500">
-                71–75 Shelton Street, Covent Garden, London WC2H 9JQ, UK<br />
-                Company No. 16517532
-              </p>
-            </div>
           </motion.div>
 
         </div>

--- a/src/components/CompanySection.tsx
+++ b/src/components/CompanySection.tsx
@@ -6,7 +6,7 @@ export default function CompanySection({ lang }: { lang: Language }) {
   const label = lang === 'fr' ? 'À propos' : 'About';
 
   return (
-    <section id="about" className="py-24 sm:py-32 border-t border-neutral-100 bg-white">
+    <section id="about" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
         <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] gap-12 md:gap-20 items-start">
 
@@ -16,11 +16,11 @@ export default function CompanySection({ lang }: { lang: Language }) {
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
           >
-            <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-400 mb-5">
+            <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-600 mb-5">
               {label}
             </p>
             <h2
-              className="font-bold tracking-tight text-black leading-tight"
+              className="font-bold tracking-tight text-white leading-tight"
               style={{ fontSize: 'clamp(1.8rem, 3.5vw, 2.5rem)' }}
             >
               {t.about.title}
@@ -33,27 +33,18 @@ export default function CompanySection({ lang }: { lang: Language }) {
             viewport={{ once: true }}
             transition={{ duration: 0.6, delay: 0.15 }}
           >
-            <p className="text-neutral-600 leading-relaxed text-base">
+            <p className="text-neutral-500 leading-relaxed text-base">
               {t.about.content}
             </p>
 
-            <div className="mt-8 flex flex-col sm:flex-row gap-6 sm:gap-10 text-sm">
-              <div>
-                <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-1">
-                  {lang === 'fr' ? 'Fondateurs' : 'Founders'}
-                </p>
-                <p className="text-black font-medium">
-                  <a href="https://www.karimhammouche.com/" target="_blank" rel="noreferrer" className="hover:underline">Karim Hammouche</a>
-                  {' & '}
-                  <a href="https://rthportofolio.com/" target="_blank" rel="noreferrer" className="hover:underline">Raphaël Theuillon</a>
-                </p>
-              </div>
-              <div>
-                <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-1">
-                  {lang === 'fr' ? 'Siège social' : 'Registered office'}
-                </p>
-                <p className="text-black">London, UK · No. 16517532</p>
-              </div>
+            <div className="mt-8 text-sm">
+              <p className="text-[10px] uppercase tracking-widest text-neutral-600 mb-1">
+                {lang === 'fr' ? 'Siège social' : 'Registered office'}
+              </p>
+              <p className="text-neutral-500">
+                71–75 Shelton Street, Covent Garden, London WC2H 9JQ, UK<br />
+                Company No. 16517532
+              </p>
             </div>
           </motion.div>
 

--- a/src/components/CompanySection.tsx
+++ b/src/components/CompanySection.tsx
@@ -1,0 +1,64 @@
+import { motion } from 'framer-motion';
+import { Language, translations } from '../data/translations';
+
+export default function CompanySection({ lang }: { lang: Language }) {
+  const t = translations[lang];
+  const label = lang === 'fr' ? 'À propos' : 'About';
+
+  return (
+    <section id="about" className="py-24 sm:py-32 border-t border-neutral-100 bg-white">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] gap-12 md:gap-20 items-start">
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-400 mb-5">
+              {label}
+            </p>
+            <h2
+              className="font-bold tracking-tight text-black leading-tight"
+              style={{ fontSize: 'clamp(1.8rem, 3.5vw, 2.5rem)' }}
+            >
+              {t.about.title}
+            </h2>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6, delay: 0.15 }}
+          >
+            <p className="text-neutral-600 leading-relaxed text-base">
+              {t.about.content}
+            </p>
+
+            <div className="mt-8 flex flex-col sm:flex-row gap-6 sm:gap-10 text-sm">
+              <div>
+                <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-1">
+                  {lang === 'fr' ? 'Fondateurs' : 'Founders'}
+                </p>
+                <p className="text-black font-medium">
+                  <a href="https://www.karimhammouche.com/" target="_blank" rel="noreferrer" className="hover:underline">Karim Hammouche</a>
+                  {' & '}
+                  <a href="https://rthportofolio.com/" target="_blank" rel="noreferrer" className="hover:underline">Raphaël Theuillon</a>
+                </p>
+              </div>
+              <div>
+                <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-1">
+                  {lang === 'fr' ? 'Siège social' : 'Registered office'}
+                </p>
+                <p className="text-black">London, UK · No. 16517532</p>
+              </div>
+            </div>
+          </motion.div>
+
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/CompanySection.tsx
+++ b/src/components/CompanySection.tsx
@@ -6,7 +6,7 @@ export default function CompanySection({ lang }: { lang: Language }) {
   const label = lang === 'fr' ? 'À propos' : 'About';
 
   return (
-    <section id="about" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
+    <section id="about" className="py-24 sm:py-32 bg-white border-t border-black/[0.06]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
         <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] gap-12 md:gap-20 items-start">
 
@@ -16,11 +16,11 @@ export default function CompanySection({ lang }: { lang: Language }) {
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
           >
-            <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-600 mb-5">
+            <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-400 mb-5">
               {label}
             </p>
             <h2
-              className="font-bold tracking-tight text-white leading-tight"
+              className="font-bold tracking-tight text-black leading-tight"
               style={{ fontSize: 'clamp(1.8rem, 3.5vw, 2.5rem)' }}
             >
               {t.about.title}
@@ -38,7 +38,7 @@ export default function CompanySection({ lang }: { lang: Language }) {
             </p>
 
             <div className="mt-8 text-sm">
-              <p className="text-[10px] uppercase tracking-widest text-neutral-600 mb-1">
+              <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-1">
                 {lang === 'fr' ? 'Siège social' : 'Registered office'}
               </p>
               <p className="text-neutral-500">

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,24 +1,28 @@
 import { motion } from 'framer-motion';
+import { useBooking } from '@/context/BookingContext';
 import type { Language } from '../data/translations';
 
-const content: Record<Language, { label: string; title: string; subtitle: string }> = {
+const content: Record<Language, { label: string; title: string; subtitle: string; calendly: string }> = {
   fr: {
     label: 'Contact',
     title: 'On est disponibles.',
-    subtitle: 'Une question, un projet ? Écrivez-nous.',
+    subtitle: 'Une question, un projet ? Écrivez-nous ou réservez un appel.',
+    calendly: 'Réserver un appel (30 min)',
   },
   en: {
     label: 'Contact',
     title: "We're available.",
-    subtitle: 'A question, a project? Write to us.',
+    subtitle: 'A question, a project? Write to us or book a call.',
+    calendly: 'Book a call (30 min)',
   },
 };
 
 export default function ContactSection({ lang }: { lang: Language }) {
   const c = content[lang];
+  const { openBooking } = useBooking();
 
   return (
-    <section id="contact" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
+    <section id="contact" className="py-24 sm:py-32 border-t border-neutral-100 bg-white">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
         <motion.div
           initial={{ opacity: 0, y: 24 }}
@@ -26,29 +30,35 @@ export default function ContactSection({ lang }: { lang: Language }) {
           viewport={{ once: true }}
           transition={{ duration: 0.65 }}
         >
-          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-600">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-400">
             {c.label}
           </p>
           <h2
-            className="mt-5 font-bold tracking-tight text-white"
+            className="mt-5 font-bold tracking-tight text-black"
             style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)' }}
           >
             {c.title}
           </h2>
           <p className="mt-3 text-neutral-500 text-sm">{c.subtitle}</p>
 
-          <div className="mt-10 flex flex-col sm:flex-row gap-4">
+          <div className="mt-10 flex flex-col sm:flex-row flex-wrap gap-4">
+            <button
+              onClick={openBooking}
+              className="inline-flex items-center justify-center gap-2 bg-black text-white rounded-full px-7 py-3 text-sm font-medium hover:bg-neutral-800 transition-colors"
+            >
+              {c.calendly}
+            </button>
             <a
               href="https://wa.me/33743561304"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center justify-center gap-2 bg-white text-black rounded-full px-7 py-3 text-sm font-medium hover:bg-neutral-200 transition-colors"
+              className="inline-flex items-center justify-center gap-2 border border-neutral-200 text-black rounded-full px-7 py-3 text-sm font-medium hover:border-black transition-colors"
             >
               WhatsApp
             </a>
             <a
               href="mailto:contact@krglobalsolutionsltd.com"
-              className="inline-flex items-center justify-center gap-2 border border-white/15 text-white rounded-full px-7 py-3 text-sm font-medium hover:border-white/40 transition-colors"
+              className="inline-flex items-center justify-center gap-2 border border-neutral-200 text-black rounded-full px-7 py-3 text-sm font-medium hover:border-black transition-colors"
             >
               contact@krglobalsolutionsltd.com
             </a>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -18,7 +18,7 @@ export default function ContactSection({ lang }: { lang: Language }) {
   const c = content[lang];
 
   return (
-    <section id="contact" className="py-24 sm:py-32 border-t border-neutral-100">
+    <section id="contact" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
         <motion.div
           initial={{ opacity: 0, y: 24 }}
@@ -26,29 +26,29 @@ export default function ContactSection({ lang }: { lang: Language }) {
           viewport={{ once: true }}
           transition={{ duration: 0.65 }}
         >
-          <p className="text-xs uppercase tracking-[0.22em] text-neutral-400">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-600">
             {c.label}
           </p>
           <h2
-            className="mt-4 font-bold tracking-tight"
+            className="mt-5 font-bold tracking-tight text-white"
             style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)' }}
           >
             {c.title}
           </h2>
-          <p className="mt-3 text-neutral-500">{c.subtitle}</p>
+          <p className="mt-3 text-neutral-500 text-sm">{c.subtitle}</p>
 
           <div className="mt-10 flex flex-col sm:flex-row gap-4">
             <a
               href="https://wa.me/33743561304"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center justify-center gap-2 bg-black text-white rounded-full px-7 py-3 text-sm font-medium hover:bg-neutral-700 transition-colors"
+              className="inline-flex items-center justify-center gap-2 bg-white text-black rounded-full px-7 py-3 text-sm font-medium hover:bg-neutral-200 transition-colors"
             >
               WhatsApp
             </a>
             <a
               href="mailto:contact@krglobalsolutionsltd.com"
-              className="inline-flex items-center justify-center gap-2 border border-neutral-200 rounded-full px-7 py-3 text-sm font-medium hover:border-black transition-colors break-all"
+              className="inline-flex items-center justify-center gap-2 border border-white/15 text-white rounded-full px-7 py-3 text-sm font-medium hover:border-white/40 transition-colors"
             >
               contact@krglobalsolutionsltd.com
             </a>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -22,7 +22,7 @@ export default function ContactSection({ lang }: { lang: Language }) {
   const { openBooking } = useBooking();
 
   return (
-    <section id="contact" className="py-24 sm:py-32 border-t border-neutral-100 bg-white">
+    <section id="contact" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
         <motion.div
           initial={{ opacity: 0, y: 24 }}
@@ -30,21 +30,21 @@ export default function ContactSection({ lang }: { lang: Language }) {
           viewport={{ once: true }}
           transition={{ duration: 0.65 }}
         >
-          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-400">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-600">
             {c.label}
           </p>
           <h2
-            className="mt-5 font-bold tracking-tight text-black"
+            className="mt-5 font-bold tracking-tight text-white"
             style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)' }}
           >
             {c.title}
           </h2>
-          <p className="mt-3 text-neutral-500 text-sm">{c.subtitle}</p>
+          <p className="mt-3 text-neutral-600 text-sm">{c.subtitle}</p>
 
           <div className="mt-10 flex flex-col sm:flex-row flex-wrap gap-4">
             <button
               onClick={openBooking}
-              className="inline-flex items-center justify-center gap-2 bg-black text-white rounded-full px-7 py-3 text-sm font-medium hover:bg-neutral-800 transition-colors"
+              className="inline-flex items-center justify-center gap-2 bg-white text-black rounded-full px-7 py-3 text-sm font-medium hover:bg-neutral-200 transition-colors"
             >
               {c.calendly}
             </button>
@@ -52,13 +52,13 @@ export default function ContactSection({ lang }: { lang: Language }) {
               href="https://wa.me/33743561304"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center justify-center gap-2 border border-neutral-200 text-black rounded-full px-7 py-3 text-sm font-medium hover:border-black transition-colors"
+              className="inline-flex items-center justify-center gap-2 border border-white/15 text-white rounded-full px-7 py-3 text-sm font-medium hover:border-white/40 transition-colors"
             >
               WhatsApp
             </a>
             <a
               href="mailto:contact@krglobalsolutionsltd.com"
-              className="inline-flex items-center justify-center gap-2 border border-neutral-200 text-black rounded-full px-7 py-3 text-sm font-medium hover:border-black transition-colors"
+              className="inline-flex items-center justify-center gap-2 border border-white/15 text-white rounded-full px-7 py-3 text-sm font-medium hover:border-white/40 transition-colors"
             >
               contact@krglobalsolutionsltd.com
             </a>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -22,7 +22,7 @@ export default function ContactSection({ lang }: { lang: Language }) {
   const { openBooking } = useBooking();
 
   return (
-    <section id="contact" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
+    <section id="contact" className="py-24 sm:py-32 bg-white border-t border-black/[0.06]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
         <motion.div
           initial={{ opacity: 0, y: 24 }}
@@ -30,21 +30,21 @@ export default function ContactSection({ lang }: { lang: Language }) {
           viewport={{ once: true }}
           transition={{ duration: 0.65 }}
         >
-          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-600">
+          <p className="text-[10px] uppercase tracking-[0.28em] text-neutral-400">
             {c.label}
           </p>
           <h2
-            className="mt-5 font-bold tracking-tight text-white"
+            className="mt-5 font-bold tracking-tight text-black"
             style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)' }}
           >
             {c.title}
           </h2>
-          <p className="mt-3 text-neutral-600 text-sm">{c.subtitle}</p>
+          <p className="mt-3 text-neutral-500 text-sm">{c.subtitle}</p>
 
           <div className="mt-10 flex flex-col sm:flex-row flex-wrap gap-4">
             <button
               onClick={openBooking}
-              className="inline-flex items-center justify-center gap-2 bg-white text-black rounded-full px-7 py-3 text-sm font-medium hover:bg-neutral-200 transition-colors"
+              className="inline-flex items-center justify-center gap-2 bg-black text-white rounded-full px-7 py-3 text-sm font-medium hover:bg-neutral-800 transition-colors"
             >
               {c.calendly}
             </button>
@@ -52,13 +52,13 @@ export default function ContactSection({ lang }: { lang: Language }) {
               href="https://wa.me/33743561304"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center justify-center gap-2 border border-white/15 text-white rounded-full px-7 py-3 text-sm font-medium hover:border-white/40 transition-colors"
+              className="inline-flex items-center justify-center gap-2 border border-black/15 text-black rounded-full px-7 py-3 text-sm font-medium hover:border-black/50 transition-colors"
             >
               WhatsApp
             </a>
             <a
               href="mailto:contact@krglobalsolutionsltd.com"
-              className="inline-flex items-center justify-center gap-2 border border-white/15 text-white rounded-full px-7 py-3 text-sm font-medium hover:border-white/40 transition-colors"
+              className="inline-flex items-center justify-center gap-2 border border-black/15 text-black rounded-full px-7 py-3 text-sm font-medium hover:border-black/50 transition-colors"
             >
               contact@krglobalsolutionsltd.com
             </a>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,0 +1,60 @@
+import { motion } from 'framer-motion';
+import type { Language } from '../data/translations';
+
+const content: Record<Language, { label: string; title: string; subtitle: string }> = {
+  fr: {
+    label: 'Contact',
+    title: 'On est disponibles.',
+    subtitle: 'Une question, un projet ? Écrivez-nous.',
+  },
+  en: {
+    label: 'Contact',
+    title: "We're available.",
+    subtitle: 'A question, a project? Write to us.',
+  },
+};
+
+export default function ContactSection({ lang }: { lang: Language }) {
+  const c = content[lang];
+
+  return (
+    <section id="contact" className="py-24 sm:py-32 border-t border-neutral-100">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.65 }}
+        >
+          <p className="text-xs uppercase tracking-[0.22em] text-neutral-400">
+            {c.label}
+          </p>
+          <h2
+            className="mt-4 font-bold tracking-tight"
+            style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)' }}
+          >
+            {c.title}
+          </h2>
+          <p className="mt-3 text-neutral-500">{c.subtitle}</p>
+
+          <div className="mt-10 flex flex-col sm:flex-row gap-4">
+            <a
+              href="https://wa.me/33743561304"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center justify-center gap-2 bg-black text-white rounded-full px-7 py-3 text-sm font-medium hover:bg-neutral-700 transition-colors"
+            >
+              WhatsApp
+            </a>
+            <a
+              href="mailto:contact@krglobalsolutionsltd.com"
+              className="inline-flex items-center justify-center gap-2 border border-neutral-200 rounded-full px-7 py-3 text-sm font-medium hover:border-black transition-colors break-all"
+            >
+              contact@krglobalsolutionsltd.com
+            </a>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,33 +6,50 @@ export function Footer() {
     typeof window !== 'undefined' ? window.location.pathname : '';
   const prefix = pathname.startsWith('/en') ? '/en' : '';
 
-  const links = [
-    {
-      label: "contact@krglobalsolutionsltd.com",
-      href: "mailto:contact@krglobalsolutionsltd.com",
-      className: "break-all",
-    },
-    { label: "Mentions légales", href: `${prefix}/mentions-legales` },
-  ];
-
   return (
-    <footer id="site-footer" className="bg-black border-t border-white/[0.06] py-8">
-      <div className="container mx-auto px-4 sm:px-6 md:px-8 grid grid-cols-1 sm:grid-cols-2 gap-4 items-start text-xs text-neutral-600">
-        <div className="flex flex-col gap-1.5 w-full min-w-0">
-          <ul className="space-y-1.5">
-            {links.map((link, i) => (
-              <li key={i}>
-                <a href={link.href} className={`hover:text-neutral-300 transition-colors ${link.className ?? ''}`}>
-                  {link.label}
+    <footer id="site-footer" className="bg-white border-t border-neutral-100 py-10">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8">
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 items-start">
+
+          <div>
+            <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-3">KR Global Solutions LTD</p>
+            <p className="text-xs text-neutral-500 leading-relaxed">
+              71–75 Shelton Street<br />
+              Covent Garden, London<br />
+              WC2H 9JQ, UK<br />
+              No. 16517532
+            </p>
+          </div>
+
+          <div>
+            <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-3">Liens</p>
+            <ul className="space-y-2 text-xs text-neutral-500">
+              <li>
+                <a href="mailto:contact@krglobalsolutionsltd.com" className="hover:text-black transition-colors break-all">
+                  contact@krglobalsolutionsltd.com
                 </a>
               </li>
-            ))}
-          </ul>
-          <p className="mt-2 text-neutral-700">© KR Global Solutions LTD 2025 · London, UK</p>
+              <li>
+                <a href={`${prefix}/mentions-legales`} className="hover:text-black transition-colors">
+                  Mentions légales
+                </a>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-3">Réseaux sociaux</p>
+            <SocialLinks variant="footer" className="flex-col items-start gap-2.5" />
+          </div>
+
         </div>
-        <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
-          <SocialLinks variant="footer" size={18} className="justify-center sm:justify-end" />
+
+        <div className="mt-10 pt-6 border-t border-neutral-100 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2 text-[10px] text-neutral-400">
+          <span>© KR Global Solutions LTD 2025 · London, UK</span>
+          <span>SIC: 46190 · 47910 · 62012 · 62090</span>
         </div>
+
       </div>
     </footer>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,7 +13,7 @@ export function Footer() {
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 items-start">
 
           <div>
-            <p className="text-[10px] uppercase tracking-widest text-neutral-700 mb-3">
+            <p className="text-[10px] uppercase tracking-widest text-neutral-500 mb-3">
               KR Global Solutions LTD
             </p>
             <p className="text-xs text-neutral-600 leading-relaxed">
@@ -25,7 +25,7 @@ export function Footer() {
           </div>
 
           <div>
-            <p className="text-[10px] uppercase tracking-widest text-neutral-700 mb-3">Liens</p>
+            <p className="text-[10px] uppercase tracking-widest text-neutral-500 mb-3">Liens</p>
             <ul className="space-y-2 text-xs text-neutral-600">
               <li>
                 <a
@@ -47,7 +47,7 @@ export function Footer() {
           </div>
 
           <div>
-            <p className="text-[10px] uppercase tracking-widest text-neutral-700 mb-3">
+            <p className="text-[10px] uppercase tracking-widest text-neutral-500 mb-3">
               Réseaux sociaux
             </p>
             <SocialLinks variant="footer" className="flex-col items-start gap-2.5" />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,22 +16,23 @@ export function Footer() {
   ];
 
   return (
-    <footer id="site-footer" className="bg-black text-white py-6">
-      <div className="container mx-auto px-4 sm:px-6 md:px-8 grid grid-cols-1 sm:grid-cols-2 gap-4 items-start text-sm">
-        <div className="flex flex-col gap-2 w-full min-w-0">
-          <ul>
+    <footer id="site-footer" className="bg-black border-t border-white/[0.06] py-8">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8 grid grid-cols-1 sm:grid-cols-2 gap-4 items-start text-xs text-neutral-600">
+        <div className="flex flex-col gap-1.5 w-full min-w-0">
+          <ul className="space-y-1.5">
             {links.map((link, i) => (
               <li key={i}>
-                <a href={link.href} className={link.className}>
+                <a href={link.href} className={`hover:text-neutral-300 transition-colors ${link.className ?? ''}`}>
                   {link.label}
                 </a>
               </li>
             ))}
           </ul>
+          <p className="mt-2 text-neutral-700">© KR Global Solutions LTD 2025 · London, UK</p>
         </div>
-          <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
-            <SocialLinks variant="footer" size={22} className="justify-center sm:justify-end" />
-          </div>
+        <div className="flex flex-col sm:items-end gap-2 w-full min-w-0">
+          <SocialLinks variant="footer" size={18} className="justify-center sm:justify-end" />
+        </div>
       </div>
     </footer>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,14 +7,16 @@ export function Footer() {
   const prefix = pathname.startsWith('/en') ? '/en' : '';
 
   return (
-    <footer id="site-footer" className="bg-white border-t border-neutral-100 py-10">
+    <footer id="site-footer" className="bg-black border-t border-white/[0.06] py-10">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 items-start">
 
           <div>
-            <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-3">KR Global Solutions LTD</p>
-            <p className="text-xs text-neutral-500 leading-relaxed">
+            <p className="text-[10px] uppercase tracking-widest text-neutral-700 mb-3">
+              KR Global Solutions LTD
+            </p>
+            <p className="text-xs text-neutral-600 leading-relaxed">
               71–75 Shelton Street<br />
               Covent Garden, London<br />
               WC2H 9JQ, UK<br />
@@ -23,15 +25,21 @@ export function Footer() {
           </div>
 
           <div>
-            <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-3">Liens</p>
-            <ul className="space-y-2 text-xs text-neutral-500">
+            <p className="text-[10px] uppercase tracking-widest text-neutral-700 mb-3">Liens</p>
+            <ul className="space-y-2 text-xs text-neutral-600">
               <li>
-                <a href="mailto:contact@krglobalsolutionsltd.com" className="hover:text-black transition-colors break-all">
+                <a
+                  href="mailto:contact@krglobalsolutionsltd.com"
+                  className="hover:text-white transition-colors break-all"
+                >
                   contact@krglobalsolutionsltd.com
                 </a>
               </li>
               <li>
-                <a href={`${prefix}/mentions-legales`} className="hover:text-black transition-colors">
+                <a
+                  href={`${prefix}/mentions-legales`}
+                  className="hover:text-white transition-colors"
+                >
                   Mentions légales
                 </a>
               </li>
@@ -39,13 +47,15 @@ export function Footer() {
           </div>
 
           <div>
-            <p className="text-[10px] uppercase tracking-widest text-neutral-400 mb-3">Réseaux sociaux</p>
+            <p className="text-[10px] uppercase tracking-widest text-neutral-700 mb-3">
+              Réseaux sociaux
+            </p>
             <SocialLinks variant="footer" className="flex-col items-start gap-2.5" />
           </div>
 
         </div>
 
-        <div className="mt-10 pt-6 border-t border-neutral-100 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2 text-[10px] text-neutral-400">
+        <div className="mt-10 pt-6 border-t border-white/[0.05] flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2 text-[10px] text-neutral-700">
           <span>© KR Global Solutions LTD 2025 · London, UK</span>
           <span>SIC: 46190 · 47910 · 62012 · 62090</span>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,27 +1,23 @@
 import React from 'react';
 import { LanguageSelector } from './LanguageSelector';
-import SocialLinks from "@/components/SocialLinks";
+import SocialLinks from '@/components/SocialLinks';
 import { Language, Translation } from '../data/translations';
-import KRLogoKR from "@/components/KRLogoKR";
-import { DarkZoneToggle } from './DarkZoneToggle';
-import { Menu, X } from "lucide-react";
-import { useBooking } from "@/context/BookingContext";
-import { useTranslation } from "react-i18next";
-import WhatsAppButton from './WhatsAppButton';
+import KRLogoKR from '@/components/KRLogoKR';
+import { Menu, X } from 'lucide-react';
 
-  interface HeaderProps {
-    currentLanguage: Language;
-    onLanguageChange: (lang: Language) => void;
-    t: Translation;
-  }
+interface HeaderProps {
+  currentLanguage: Language;
+  onLanguageChange: (lang: Language) => void;
+  t: Translation;
+}
 
-  export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
-    const { openBooking } = useBooking();
-    const { t: tI18n } = useTranslation();
-    const [open, setOpen] = React.useState(false);
-    return (
-    <header className="sticky top-0 z-[100] bg-white/80 backdrop-blur-md border-b border-neutral-200 dz-card dz-border dz-fg">
+export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <header className="sticky top-0 z-[100] bg-white/80 backdrop-blur-md border-b border-neutral-200">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 h-16 flex items-center justify-between">
+
         <div className="flex items-center gap-3 min-w-0">
           <KRLogoKR
             intensity="max"
@@ -33,18 +29,10 @@ import WhatsAppButton from './WhatsAppButton';
             onLanguageChange={onLanguageChange}
             t={t}
           />
-          {/* SAFE-GUARD: isolated toggle to avoid interfering with existing nav */}
-          <DarkZoneToggle label={t.nav.darkZone} />
         </div>
+
         <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
-            <button
-              className="btn-primary ml-4 hidden sm:inline-flex text-sm"
-              onClick={openBooking}
-            >
-              {tI18n("booking.buttonCall")}
-            </button>
           <SocialLinks variant="header" size={20} className="justify-end hidden md:flex" />
-          <WhatsAppButton className="hidden md:inline-flex" />
           <button
             className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50"
             onClick={() => setOpen((o) => !o)}
@@ -53,12 +41,13 @@ import WhatsAppButton from './WhatsAppButton';
             {open ? <X size={20} /> : <Menu size={20} />}
           </button>
         </div>
+
       </div>
+
       {open && (
-        <nav className="md:hidden border-t border-neutral-200 dz-border bg-white dz-card">
-          <div className="flex flex-col items-start p-4 gap-2">
-            <SocialLinks variant="header" size={20} className="flex-col items-start gap-2" />
-            <WhatsAppButton />
+        <nav className="md:hidden border-t border-neutral-200 bg-white">
+          <div className="flex flex-col items-start p-4 gap-3">
+            <SocialLinks variant="header" size={20} className="flex-col items-start gap-3" />
           </div>
         </nav>
       )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,8 @@ import SocialLinks from '@/components/SocialLinks';
 import { Language, Translation } from '../data/translations';
 import KRLogoKR from '@/components/KRLogoKR';
 import { Menu, X } from 'lucide-react';
+import { useBooking } from '@/context/BookingContext';
+import { useTranslation } from 'react-i18next';
 
 interface HeaderProps {
   currentLanguage: Language;
@@ -13,9 +15,11 @@ interface HeaderProps {
 
 export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
   const [open, setOpen] = React.useState(false);
+  const { openBooking } = useBooking();
+  const { t: tI18n } = useTranslation();
 
   return (
-    <header className="sticky top-0 z-[100] bg-black/80 backdrop-blur-md border-b border-white/[0.06]">
+    <header className="sticky top-0 z-[100] bg-white/90 backdrop-blur-md border-b border-neutral-100">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 h-16 flex items-center justify-between">
 
         <div className="flex items-center gap-3 min-w-0">
@@ -31,23 +35,35 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
           />
         </div>
 
-        <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
-          <SocialLinks variant="header" size={18} className="justify-end hidden md:flex" />
+        <div className="flex items-center justify-end flex-1 overflow-hidden gap-4">
+          <SocialLinks variant="header" size={15} className="hidden lg:flex" />
           <button
-            className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
+            className="hidden sm:inline-flex items-center justify-center rounded-full border border-black px-4 py-1.5 text-xs font-medium hover:bg-black hover:text-white transition-colors whitespace-nowrap"
+            onClick={openBooking}
+          >
+            {tI18n('booking.buttonCall')}
+          </button>
+          <button
+            className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-full hover:bg-neutral-100 transition-colors focus-visible:outline-none"
             onClick={() => setOpen((o) => !o)}
             aria-label={open ? 'Fermer le menu' : 'Menu'}
           >
-            {open ? <X size={20} /> : <Menu size={20} />}
+            {open ? <X size={18} /> : <Menu size={18} />}
           </button>
         </div>
 
       </div>
 
       {open && (
-        <nav className="md:hidden border-t border-white/[0.06] bg-black">
-          <div className="flex flex-col items-start p-4 gap-3">
-            <SocialLinks variant="header" size={18} className="flex-col items-start gap-3" />
+        <nav className="md:hidden border-t border-neutral-100 bg-white">
+          <div className="container mx-auto px-4 py-5 flex flex-col gap-5">
+            <SocialLinks variant="header" size={16} className="flex-wrap" />
+            <button
+              className="self-start rounded-full border border-black px-5 py-2 text-sm font-medium hover:bg-black hover:text-white transition-colors"
+              onClick={() => { setOpen(false); openBooking(); }}
+            >
+              {tI18n('booking.buttonCall')}
+            </button>
           </div>
         </nav>
       )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { LanguageSelector } from './LanguageSelector';
-import SocialLinks from '@/components/SocialLinks';
 import { Language, Translation } from '../data/translations';
 import KRLogoKR from '@/components/KRLogoKR';
 import { Menu, X } from 'lucide-react';
@@ -19,10 +18,10 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
   const { t: tI18n } = useTranslation();
 
   return (
-    <header className="sticky top-0 z-[100] bg-white/90 backdrop-blur-md border-b border-neutral-100">
+    <header className="sticky top-0 z-[100] bg-black/80 backdrop-blur-md border-b border-white/[0.05]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 h-16 flex items-center justify-between">
 
-        <div className="flex items-center gap-3 min-w-0">
+        <div className="flex items-center gap-3 min-w-0 text-white">
           <KRLogoKR
             intensity="max"
             hrefK="https://www.karimhammouche.com/"
@@ -35,16 +34,15 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
           />
         </div>
 
-        <div className="flex items-center justify-end flex-1 overflow-hidden gap-4">
-          <SocialLinks variant="header" size={15} className="hidden lg:flex" />
+        <div className="flex items-center gap-3">
           <button
-            className="hidden sm:inline-flex items-center justify-center rounded-full border border-black px-4 py-1.5 text-xs font-medium hover:bg-black hover:text-white transition-colors whitespace-nowrap"
+            className="hidden sm:inline-flex items-center justify-center rounded-full border border-white/20 px-5 py-1.5 text-xs font-medium text-white hover:bg-white hover:text-black transition-colors whitespace-nowrap"
             onClick={openBooking}
           >
             {tI18n('booking.buttonCall')}
           </button>
           <button
-            className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-full hover:bg-neutral-100 transition-colors focus-visible:outline-none"
+            className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-full text-white hover:bg-white/10 transition-colors"
             onClick={() => setOpen((o) => !o)}
             aria-label={open ? 'Fermer le menu' : 'Menu'}
           >
@@ -55,11 +53,10 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
       </div>
 
       {open && (
-        <nav className="md:hidden border-t border-neutral-100 bg-white">
-          <div className="container mx-auto px-4 py-5 flex flex-col gap-5">
-            <SocialLinks variant="header" size={16} className="flex-wrap" />
+        <nav className="md:hidden border-t border-white/[0.05] bg-black">
+          <div className="container mx-auto px-4 py-5 flex flex-col gap-4">
             <button
-              className="self-start rounded-full border border-black px-5 py-2 text-sm font-medium hover:bg-black hover:text-white transition-colors"
+              className="self-start rounded-full border border-white/20 px-5 py-2 text-sm text-white font-medium hover:bg-white hover:text-black transition-colors"
               onClick={() => { setOpen(false); openBooking(); }}
             >
               {tI18n('booking.buttonCall')}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,7 +15,7 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <header className="sticky top-0 z-[100] bg-white/80 backdrop-blur-md border-b border-neutral-200">
+    <header className="sticky top-0 z-[100] bg-black/80 backdrop-blur-md border-b border-white/[0.06]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 h-16 flex items-center justify-between">
 
         <div className="flex items-center gap-3 min-w-0">
@@ -32,9 +32,9 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
         </div>
 
         <div className="flex items-center justify-end flex-1 overflow-hidden gap-2">
-          <SocialLinks variant="header" size={20} className="justify-end hidden md:flex" />
+          <SocialLinks variant="header" size={18} className="justify-end hidden md:flex" />
           <button
-            className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50"
+            className="md:hidden inline-flex items-center justify-center min-h-11 px-4 rounded-full text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
             onClick={() => setOpen((o) => !o)}
             aria-label={open ? 'Fermer le menu' : 'Menu'}
           >
@@ -45,9 +45,9 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
       </div>
 
       {open && (
-        <nav className="md:hidden border-t border-neutral-200 bg-white">
+        <nav className="md:hidden border-t border-white/[0.06] bg-black">
           <div className="flex flex-col items-start p-4 gap-3">
-            <SocialLinks variant="header" size={20} className="flex-col items-start gap-3" />
+            <SocialLinks variant="header" size={18} className="flex-col items-start gap-3" />
           </div>
         </nav>
       )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,10 +18,10 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
   const { t: tI18n } = useTranslation();
 
   return (
-    <header className="sticky top-0 z-[100] bg-black/80 backdrop-blur-md border-b border-white/[0.05]">
+    <header className="sticky top-0 z-[100] bg-white/90 backdrop-blur-md border-b border-black/[0.07]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 h-16 flex items-center justify-between">
 
-        <div className="flex items-center gap-3 min-w-0 text-white">
+        <div className="flex items-center gap-3 min-w-0 text-black">
           <KRLogoKR
             intensity="max"
             hrefK="https://www.karimhammouche.com/"
@@ -36,13 +36,13 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
 
         <div className="flex items-center gap-3">
           <button
-            className="hidden sm:inline-flex items-center justify-center rounded-full border border-white/20 px-5 py-1.5 text-xs font-medium text-white hover:bg-white hover:text-black transition-colors whitespace-nowrap"
+            className="hidden sm:inline-flex items-center justify-center rounded-full border border-black/20 px-5 py-1.5 text-xs font-medium text-black hover:bg-black hover:text-white transition-colors whitespace-nowrap"
             onClick={openBooking}
           >
             {tI18n('booking.buttonCall')}
           </button>
           <button
-            className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-full text-white hover:bg-white/10 transition-colors"
+            className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-full text-black hover:bg-black/10 transition-colors"
             onClick={() => setOpen((o) => !o)}
             aria-label={open ? 'Fermer le menu' : 'Menu'}
           >
@@ -53,10 +53,10 @@ export function Header({ currentLanguage, onLanguageChange, t }: HeaderProps) {
       </div>
 
       {open && (
-        <nav className="md:hidden border-t border-white/[0.05] bg-black">
+        <nav className="md:hidden border-t border-black/[0.07] bg-white">
           <div className="container mx-auto px-4 py-5 flex flex-col gap-4">
             <button
-              className="self-start rounded-full border border-white/20 px-5 py-2 text-sm text-white font-medium hover:bg-white hover:text-black transition-colors"
+              className="self-start rounded-full border border-black/20 px-5 py-2 text-sm text-black font-medium hover:bg-black hover:text-white transition-colors"
               onClick={() => { setOpen(false); openBooking(); }}
             >
               {tI18n('booking.buttonCall')}

--- a/src/components/HeroNew.tsx
+++ b/src/components/HeroNew.tsx
@@ -1,0 +1,74 @@
+import { Suspense, lazy } from 'react';
+import { motion } from 'framer-motion';
+import type { Language } from '../data/translations';
+
+const FloatingShape = lazy(() => import('./three/FloatingShape'));
+
+const content: Record<Language, { tagline: string; company: string; cta: string }> = {
+  fr: {
+    tagline: 'Solutions digitales & IA pour les entreprises modernes.',
+    company: 'KR Global Solutions LTD · Londres, UK',
+    cta: 'Voir nos projets',
+  },
+  en: {
+    tagline: 'Digital solutions & AI for modern businesses.',
+    company: 'KR Global Solutions LTD · London, UK',
+    cta: 'See our projects',
+  },
+};
+
+export default function HeroNew({ lang }: { lang: Language }) {
+  const c = content[lang];
+
+  return (
+    <section className="min-h-[calc(100vh-4rem)] flex items-center">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8 w-full py-16 md:py-0">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-16 items-center">
+
+          {/* Text */}
+          <motion.div
+            initial={{ opacity: 0, y: 28 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.75, ease: 'easeOut' }}
+          >
+            <h1
+              className="font-bold tracking-tight leading-[0.92]"
+              style={{ fontSize: 'clamp(3.5rem, 9vw, 7rem)' }}
+            >
+              KR<br />Global<br />LTD
+            </h1>
+
+            <p className="mt-6 text-neutral-500 leading-relaxed max-w-xs" style={{ fontSize: 'clamp(1rem, 1.4vw, 1.1rem)' }}>
+              {c.tagline}
+            </p>
+
+            <p className="mt-3 text-xs text-neutral-400 tracking-wide">
+              {c.company}
+            </p>
+
+            <a
+              href="#projects"
+              className="mt-10 inline-flex items-center gap-2 text-sm font-medium border-b border-black pb-0.5 hover:opacity-40 transition-opacity"
+            >
+              {c.cta}
+              <span aria-hidden>↓</span>
+            </a>
+          </motion.div>
+
+          {/* 3D Canvas */}
+          <motion.div
+            className="h-64 sm:h-80 md:h-[520px]"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 1.4, delay: 0.2 }}
+          >
+            <Suspense fallback={null}>
+              <FloatingShape />
+            </Suspense>
+          </motion.div>
+
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/HeroNew.tsx
+++ b/src/components/HeroNew.tsx
@@ -8,12 +8,12 @@ const content: Record<Language, { tagline: string; company: string; cta: string 
   fr: {
     tagline: 'Solutions digitales & IA pour les entreprises modernes.',
     company: 'KR Global Solutions LTD · Londres, UK',
-    cta: 'Voir nos projets',
+    cta: 'Découvrir nos projets',
   },
   en: {
     tagline: 'Digital solutions & AI for modern businesses.',
     company: 'KR Global Solutions LTD · London, UK',
-    cta: 'See our projects',
+    cta: 'Explore our projects',
   },
 };
 
@@ -21,18 +21,17 @@ export default function HeroNew({ lang }: { lang: Language }) {
   const c = content[lang];
 
   return (
-    <section className="min-h-[calc(100vh-4rem)] flex items-center bg-black">
+    <section className="min-h-[calc(100vh-4rem)] flex items-center bg-white">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 w-full py-16 md:py-0">
         <div className="grid grid-cols-1 md:grid-cols-[5fr_7fr] gap-8 items-center">
 
-          {/* Text */}
           <motion.div
             initial={{ opacity: 0, y: 28 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.85, ease: 'easeOut' }}
           >
             <h1
-              className="font-bold tracking-tight leading-[0.90] text-white"
+              className="font-bold tracking-tight leading-[0.90] text-black"
               style={{ fontSize: 'clamp(3.5rem, 8vw, 6.5rem)' }}
             >
               KR<br />Global<br />LTD
@@ -45,20 +44,19 @@ export default function HeroNew({ lang }: { lang: Language }) {
               {c.tagline}
             </p>
 
-            <p className="mt-2 text-[11px] text-neutral-700 tracking-widest uppercase">
+            <p className="mt-2 text-[11px] text-neutral-400 tracking-widest uppercase">
               {c.company}
             </p>
 
             <a
               href="#projects"
-              className="mt-10 inline-flex items-center gap-2 text-sm text-white font-medium border-b border-white/20 pb-px hover:border-white/60 transition-colors"
+              className="mt-10 inline-flex items-center gap-2 text-sm text-black font-medium border-b border-black/20 pb-px hover:border-black transition-colors"
             >
               {c.cta}
               <span aria-hidden>↓</span>
             </a>
           </motion.div>
 
-          {/* 3D Canvas */}
           <motion.div
             className="h-72 sm:h-[420px] md:h-[640px]"
             initial={{ opacity: 0 }}

--- a/src/components/HeroNew.tsx
+++ b/src/components/HeroNew.tsx
@@ -1,99 +1,150 @@
-import { Suspense, lazy } from 'react';
 import { motion } from 'framer-motion';
+import { useBooking } from '@/context/BookingContext';
+import InfiniteHeadline from './InfiniteHeadline';
 import type { Language } from '../data/translations';
 
-const FloatingShape = lazy(() => import('./three/FloatingShape'));
-
-const content: Record<Language, { label: string; tagline: string; cta: string }> = {
+const content: Record<Language, {
+  label: string;
+  titleWords: string[];
+  tagline: string;
+  ctaBook: string;
+  ctaExplore: string;
+}> = {
   fr: {
-    label: 'Solutions Digitales & IA',
+    label: 'Londres · Royaume-Uni · Est. 2025',
+    titleWords: ['KR', 'Global', 'Solutions'],
     tagline: 'Nous concevons des produits digitaux et des systèmes IA pour les entreprises modernes.',
-    cta: 'Découvrir',
+    ctaBook: 'Réserver un appel',
+    ctaExplore: 'Découvrir',
   },
   en: {
-    label: 'Digital Solutions & AI',
+    label: 'London · United Kingdom · Est. 2025',
+    titleWords: ['KR', 'Global', 'Solutions'],
     tagline: 'We design digital products and AI systems for modern businesses.',
-    cta: 'Explore',
+    ctaBook: 'Book a call',
+    ctaExplore: 'Explore',
   },
+};
+
+const wordVariant = {
+  hidden: { opacity: 0, y: 48, skewY: 4 },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    skewY: 0,
+    transition: { delay: 0.1 + i * 0.14, duration: 0.75, ease: [0.22, 1, 0.36, 1] },
+  }),
 };
 
 export default function HeroNew({ lang }: { lang: Language }) {
   const c = content[lang];
+  const { openBooking } = useBooking();
 
   return (
-    <section className="min-h-screen bg-black flex flex-col relative overflow-hidden">
+    <div className="bg-white">
+      <section className="min-h-screen bg-white flex flex-col relative overflow-hidden">
 
-      {/* Top ambient label */}
-      <motion.div
-        className="absolute top-8 left-0 right-0 flex justify-between items-center px-6 sm:px-10 z-10 pointer-events-none"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 1.2, delay: 1 }}
-      >
-        <span className="text-[10px] uppercase tracking-[0.3em] text-neutral-700">
-          KR Global Solutions LTD
-        </span>
-        <span className="text-[10px] uppercase tracking-[0.3em] text-neutral-700 hidden sm:block">
-          London · UK · Est. 2025
-        </span>
-      </motion.div>
-
-      {/* Center: stacked title + cube + tagline */}
-      <div className="flex-1 flex flex-col items-center justify-center px-4 py-20">
-
-        {/* Title above cube */}
-        <motion.h1
-          className="text-white font-bold tracking-[0.04em] leading-none text-center mb-10 sm:mb-14"
-          style={{ fontSize: 'clamp(2.8rem, 7vw, 5.5rem)' }}
-          initial={{ opacity: 0, y: 24 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.9, ease: 'easeOut' }}
-        >
-          KR Global LTD
-        </motion.h1>
-
-        {/* The cube — main visual */}
+        {/* Top ambient label */}
         <motion.div
-          className="w-full max-w-xl"
-          style={{ height: 'clamp(300px, 52vh, 520px)' }}
-          initial={{ opacity: 0, scale: 0.92 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 1.6, delay: 0.3, ease: 'easeOut' }}
-        >
-          <Suspense fallback={null}>
-            <FloatingShape />
-          </Suspense>
-        </motion.div>
-
-        {/* Tagline below cube */}
-        <motion.p
-          className="mt-10 sm:mt-14 text-neutral-600 text-sm text-center max-w-sm leading-relaxed"
+          className="absolute top-8 left-0 right-0 flex justify-between items-center px-6 sm:px-10 pointer-events-none"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          transition={{ duration: 1, delay: 0.9 }}
+          transition={{ duration: 1.2, delay: 0.8 }}
         >
-          {c.tagline}
-        </motion.p>
+          <span className="text-[10px] uppercase tracking-[0.3em] text-neutral-400">
+            KR Global Solutions LTD
+          </span>
+          <span className="text-[10px] uppercase tracking-[0.3em] text-neutral-400 hidden sm:block">
+            {c.label}
+          </span>
+        </motion.div>
 
-      </div>
+        {/* Main hero content */}
+        <div className="flex-1 flex flex-col items-center justify-center px-4 sm:px-10 py-24 text-center">
 
-      {/* Scroll hint */}
-      <motion.div
-        className="flex justify-center pb-10"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 1, delay: 1.4 }}
-      >
-        <a
-          href="#about"
-          className="text-[10px] uppercase tracking-[0.3em] text-neutral-700 hover:text-white transition-colors flex items-center gap-3"
+          {/* Animated title */}
+          <h1
+            className="font-bold tracking-tight leading-[0.92] text-black overflow-hidden"
+            style={{ fontSize: 'clamp(3.5rem, 11vw, 9rem)' }}
+          >
+            {c.titleWords.map((word, i) => (
+              <motion.span
+                key={word}
+                className="inline-block mr-[0.22em] last:mr-0"
+                custom={i}
+                variants={wordVariant}
+                initial="hidden"
+                animate="visible"
+              >
+                {word}
+              </motion.span>
+            ))}
+          </h1>
+
+          {/* LTD sub-label */}
+          <motion.p
+            className="mt-4 text-[11px] uppercase tracking-[0.35em] text-neutral-400"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.65, duration: 0.8 }}
+          >
+            Limited · Company No. 16517532
+          </motion.p>
+
+          {/* Tagline */}
+          <motion.p
+            className="mt-8 text-base sm:text-lg text-neutral-500 max-w-xl leading-relaxed"
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.75, duration: 0.8 }}
+          >
+            {c.tagline}
+          </motion.p>
+
+          {/* CTA buttons */}
+          <motion.div
+            className="mt-10 flex flex-col sm:flex-row gap-3"
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.9, duration: 0.7 }}
+          >
+            <button
+              onClick={openBooking}
+              className="rounded-full bg-black text-white px-8 py-3 text-sm font-medium hover:bg-neutral-800 transition-colors"
+            >
+              {c.ctaBook}
+            </button>
+            <a
+              href="#about"
+              className="rounded-full border border-black/20 text-black px-8 py-3 text-sm font-medium hover:border-black/60 transition-colors"
+            >
+              {c.ctaExplore}
+            </a>
+          </motion.div>
+
+        </div>
+
+        {/* Scroll hint */}
+        <motion.div
+          className="flex justify-center pb-10"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 1, delay: 1.3 }}
         >
-          <span className="w-8 h-px bg-neutral-800 inline-block" />
-          {c.cta}
-          <span className="w-8 h-px bg-neutral-800 inline-block" />
-        </a>
-      </motion.div>
+          <a
+            href="#about"
+            className="text-[10px] uppercase tracking-[0.3em] text-neutral-400 hover:text-black transition-colors flex items-center gap-3"
+          >
+            <span className="w-8 h-px bg-neutral-300 inline-block" />
+            <span>↓</span>
+            <span className="w-8 h-px bg-neutral-300 inline-block" />
+          </a>
+        </motion.div>
 
-    </section>
+      </section>
+
+      {/* Marquee strip — full width, between hero and next section */}
+      <InfiniteHeadline speed={28} switchEvery={4500} />
+    </div>
   );
 }

--- a/src/components/HeroNew.tsx
+++ b/src/components/HeroNew.tsx
@@ -4,16 +4,16 @@ import type { Language } from '../data/translations';
 
 const FloatingShape = lazy(() => import('./three/FloatingShape'));
 
-const content: Record<Language, { tagline: string; company: string; cta: string }> = {
+const content: Record<Language, { label: string; tagline: string; cta: string }> = {
   fr: {
-    tagline: 'Solutions digitales & IA pour les entreprises modernes.',
-    company: 'KR Global Solutions LTD · Londres, UK',
-    cta: 'Découvrir nos projets',
+    label: 'Solutions Digitales & IA',
+    tagline: 'Nous concevons des produits digitaux et des systèmes IA pour les entreprises modernes.',
+    cta: 'Découvrir',
   },
   en: {
-    tagline: 'Digital solutions & AI for modern businesses.',
-    company: 'KR Global Solutions LTD · London, UK',
-    cta: 'Explore our projects',
+    label: 'Digital Solutions & AI',
+    tagline: 'We design digital products and AI systems for modern businesses.',
+    cta: 'Explore',
   },
 };
 
@@ -21,55 +21,79 @@ export default function HeroNew({ lang }: { lang: Language }) {
   const c = content[lang];
 
   return (
-    <section className="min-h-[calc(100vh-4rem)] flex items-center bg-white">
-      <div className="container mx-auto px-4 sm:px-6 md:px-8 w-full py-16 md:py-0">
-        <div className="grid grid-cols-1 md:grid-cols-[5fr_7fr] gap-8 items-center">
+    <section className="min-h-screen bg-black flex flex-col relative overflow-hidden">
 
-          <motion.div
-            initial={{ opacity: 0, y: 28 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.85, ease: 'easeOut' }}
-          >
-            <h1
-              className="font-bold tracking-tight leading-[0.90] text-black"
-              style={{ fontSize: 'clamp(3.5rem, 8vw, 6.5rem)' }}
-            >
-              KR<br />Global<br />LTD
-            </h1>
+      {/* Top ambient label */}
+      <motion.div
+        className="absolute top-8 left-0 right-0 flex justify-between items-center px-6 sm:px-10 z-10 pointer-events-none"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 1.2, delay: 1 }}
+      >
+        <span className="text-[10px] uppercase tracking-[0.3em] text-neutral-700">
+          KR Global Solutions LTD
+        </span>
+        <span className="text-[10px] uppercase tracking-[0.3em] text-neutral-700 hidden sm:block">
+          London · UK · Est. 2025
+        </span>
+      </motion.div>
 
-            <p
-              className="mt-7 text-neutral-500 leading-relaxed max-w-[18rem]"
-              style={{ fontSize: 'clamp(0.85rem, 1.1vw, 0.95rem)' }}
-            >
-              {c.tagline}
-            </p>
+      {/* Center: stacked title + cube + tagline */}
+      <div className="flex-1 flex flex-col items-center justify-center px-4 py-20">
 
-            <p className="mt-2 text-[11px] text-neutral-400 tracking-widest uppercase">
-              {c.company}
-            </p>
+        {/* Title above cube */}
+        <motion.h1
+          className="text-white font-bold tracking-[0.04em] leading-none text-center mb-10 sm:mb-14"
+          style={{ fontSize: 'clamp(2.8rem, 7vw, 5.5rem)' }}
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.9, ease: 'easeOut' }}
+        >
+          KR Global LTD
+        </motion.h1>
 
-            <a
-              href="#projects"
-              className="mt-10 inline-flex items-center gap-2 text-sm text-black font-medium border-b border-black/20 pb-px hover:border-black transition-colors"
-            >
-              {c.cta}
-              <span aria-hidden>↓</span>
-            </a>
-          </motion.div>
+        {/* The cube — main visual */}
+        <motion.div
+          className="w-full max-w-xl"
+          style={{ height: 'clamp(300px, 52vh, 520px)' }}
+          initial={{ opacity: 0, scale: 0.92 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 1.6, delay: 0.3, ease: 'easeOut' }}
+        >
+          <Suspense fallback={null}>
+            <FloatingShape />
+          </Suspense>
+        </motion.div>
 
-          <motion.div
-            className="h-72 sm:h-[420px] md:h-[640px]"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 1.6, delay: 0.25 }}
-          >
-            <Suspense fallback={null}>
-              <FloatingShape />
-            </Suspense>
-          </motion.div>
+        {/* Tagline below cube */}
+        <motion.p
+          className="mt-10 sm:mt-14 text-neutral-600 text-sm text-center max-w-sm leading-relaxed"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 1, delay: 0.9 }}
+        >
+          {c.tagline}
+        </motion.p>
 
-        </div>
       </div>
+
+      {/* Scroll hint */}
+      <motion.div
+        className="flex justify-center pb-10"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 1, delay: 1.4 }}
+      >
+        <a
+          href="#about"
+          className="text-[10px] uppercase tracking-[0.3em] text-neutral-700 hover:text-white transition-colors flex items-center gap-3"
+        >
+          <span className="w-8 h-px bg-neutral-800 inline-block" />
+          {c.cta}
+          <span className="w-8 h-px bg-neutral-800 inline-block" />
+        </a>
+      </motion.div>
+
     </section>
   );
 }

--- a/src/components/HeroNew.tsx
+++ b/src/components/HeroNew.tsx
@@ -21,34 +21,37 @@ export default function HeroNew({ lang }: { lang: Language }) {
   const c = content[lang];
 
   return (
-    <section className="min-h-[calc(100vh-4rem)] flex items-center">
+    <section className="min-h-[calc(100vh-4rem)] flex items-center bg-black">
       <div className="container mx-auto px-4 sm:px-6 md:px-8 w-full py-16 md:py-0">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-16 items-center">
+        <div className="grid grid-cols-1 md:grid-cols-[5fr_7fr] gap-8 items-center">
 
           {/* Text */}
           <motion.div
             initial={{ opacity: 0, y: 28 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.75, ease: 'easeOut' }}
+            transition={{ duration: 0.85, ease: 'easeOut' }}
           >
             <h1
-              className="font-bold tracking-tight leading-[0.92]"
-              style={{ fontSize: 'clamp(3.5rem, 9vw, 7rem)' }}
+              className="font-bold tracking-tight leading-[0.90] text-white"
+              style={{ fontSize: 'clamp(3.5rem, 8vw, 6.5rem)' }}
             >
               KR<br />Global<br />LTD
             </h1>
 
-            <p className="mt-6 text-neutral-500 leading-relaxed max-w-xs" style={{ fontSize: 'clamp(1rem, 1.4vw, 1.1rem)' }}>
+            <p
+              className="mt-7 text-neutral-500 leading-relaxed max-w-[18rem]"
+              style={{ fontSize: 'clamp(0.85rem, 1.1vw, 0.95rem)' }}
+            >
               {c.tagline}
             </p>
 
-            <p className="mt-3 text-xs text-neutral-400 tracking-wide">
+            <p className="mt-2 text-[11px] text-neutral-700 tracking-widest uppercase">
               {c.company}
             </p>
 
             <a
               href="#projects"
-              className="mt-10 inline-flex items-center gap-2 text-sm font-medium border-b border-black pb-0.5 hover:opacity-40 transition-opacity"
+              className="mt-10 inline-flex items-center gap-2 text-sm text-white font-medium border-b border-white/20 pb-px hover:border-white/60 transition-colors"
             >
               {c.cta}
               <span aria-hidden>↓</span>
@@ -57,10 +60,10 @@ export default function HeroNew({ lang }: { lang: Language }) {
 
           {/* 3D Canvas */}
           <motion.div
-            className="h-64 sm:h-80 md:h-[520px]"
+            className="h-72 sm:h-[420px] md:h-[640px]"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            transition={{ duration: 1.4, delay: 0.2 }}
+            transition={{ duration: 1.6, delay: 0.25 }}
           >
             <Suspense fallback={null}>
               <FloatingShape />

--- a/src/components/InfiniteHeadline.tsx
+++ b/src/components/InfiniteHeadline.tsx
@@ -1,54 +1,52 @@
-"use client";
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
 
+const MESSAGES = [
+  { lang: "fr", dir: "ltr", text: "KR Global Solutions — Connecter l'innovation au monde" },
+  { lang: "en", dir: "ltr", text: "KR Global Solutions — Connecting innovation to the world" },
+  { lang: "ar", dir: "rtl", text: "KR Global Solutions — نربط الابتكار بالعالم" },
+  { lang: "ja", dir: "ltr", text: "KR Global Solutions — 世界へイノベーションをつなぐ" },
+];
+
 export default function InfiniteHeadline({
-  speed = 35,         // px/s
-  switchEvery = 5000, // ms
-}: { speed?: number; switchEvery?: number }) {
-  const messages = useMemo(
-    () => [
-      { lang: "fr", dir: "ltr", text: "KR Global Solutions — Connecter l'innovation au monde" },
-      { lang: "en", dir: "ltr", text: "KR Global Solutions — Connecting innovation to the world" },
-      { lang: "ar", dir: "rtl", text: "KR Global Solutions — نربط الابتكار بالعالم" },
-      { lang: "ja", dir: "ltr", text: "KR Global Solutions — 世界へイノベーションをつなぐ" },
-    ],
-    []
-  );
-
+  speed = 35,
+  switchEvery = 5000,
+}: {
+  speed?: number;
+  switchEvery?: number;
+}) {
   const [idx, setIdx] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => setIdx((i) => (i + 1) % messages.length), switchEvery);
-    return () => clearInterval(id);
-  }, [switchEvery, messages.length]);
 
-  const current = messages[idx];
+  useEffect(() => {
+    const id = setInterval(() => setIdx((i) => (i + 1) % MESSAGES.length), switchEvery);
+    return () => clearInterval(id);
+  }, [switchEvery]);
+
+  const current = MESSAGES[idx];
+  const duration = `${Math.max(10, Math.floor(1200 / speed))}s`;
 
   return (
-    <div className="w-full overflow-hidden border-y border-neutral-200 dark:border-neutral-800 select-none">
+    <div
+      className="w-full overflow-hidden border-y border-neutral-200 select-none bg-white"
+      aria-hidden
+    >
       <div
         key={current.lang}
         lang={current.lang}
         dir={current.dir as "ltr" | "rtl"}
-        className="relative whitespace-nowrap py-3"
-        style={{
-          "--marquee-duration": `${Math.max(10, Math.floor(1200 / speed))}s`,
-        } as CSSProperties}
+        className="relative whitespace-nowrap py-4"
+        style={{ "--marquee-duration": duration } as CSSProperties}
       >
-        <div className="marquee inline-flex">
+        <div className="marquee-track inline-flex">
           {Array.from({ length: 8 }).map((_, i) => (
-            <span key={i} className="mx-6 text-2xl md:text-4xl font-extrabold tracking-tight">
+            <span
+              key={i}
+              className="mx-8 text-xl md:text-2xl font-bold tracking-tight text-black"
+            >
               {current.text}
             </span>
           ))}
         </div>
       </div>
-      <style jsx>{`
-        .marquee { animation: marquee linear var(--marquee-duration) infinite; will-change: transform; }
-        @keyframes marquee {
-          from { transform: translateX(0); }
-          to   { transform: translateX(-50%); }
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/components/KRLogo.tsx
+++ b/src/components/KRLogo.tsx
@@ -94,19 +94,6 @@ export default function KRLogo({ t }: KRLogoProps) {
             onMouseLeave={handleLeave}
           >
             {letter}
-            <AnimatePresence>
-              {showTooltip === letter && (
-                <motion.div
-                  variants={tooltipVariants}
-                  initial="hidden"
-                  animate="visible"
-                  exit="exit"
-                  className="absolute left-1/2 -translate-x-1/2 -top-6 bg-background/90 text-foreground text-xs px-2 py-1 rounded-md shadow-md whitespace-nowrap"
-                >
-                  {letter === "K" ? t.portfolio.karim : t.portfolio.raphael}
-                </motion.div>
-              )}
-            </AnimatePresence>
           </motion.span>
         );
       })}

--- a/src/components/KRLogoIdlePortal.tsx
+++ b/src/components/KRLogoIdlePortal.tsx
@@ -86,7 +86,7 @@ export default function KRLogoIdlePortal({
         <motion.button
           ref={k.anchorRef}
           type="button"
-          aria-label="Portfolio Karim"
+          aria-label="Portfolio K"
           className="font-bold text-base md:text-lg leading-none"
           variants={idle} animate="animate" whileHover="whileHover" whileTap="whileTap"
           onMouseEnter={k.update}
@@ -99,7 +99,7 @@ export default function KRLogoIdlePortal({
         <motion.button
           ref={r.anchorRef}
           type="button"
-          aria-label="Portfolio Raphaël"
+          aria-label="Portfolio R"
           className="font-bold text-base md:text-lg leading-none"
           variants={idle} animate="animate" whileHover="whileHover" whileTap="whileTap"
           onMouseEnter={r.update}
@@ -110,9 +110,8 @@ export default function KRLogoIdlePortal({
         </motion.button>
       </div>
 
-      {/* Tooltips portalisées (pas coupées par le header) */}
-      {showTooltips && <TooltipPortal text="Portfolio Karim" pos={k.pos} />}
-      {showTooltips && <TooltipPortal text="Portfolio Raphaël" pos={r.pos} />}
+      {showTooltips && <TooltipPortal text="Portfolio K" pos={k.pos} />}
+      {showTooltips && <TooltipPortal text="Portfolio R" pos={r.pos} />}
 
       {/* Respect prefers-reduced-motion */}
       <style jsx global>{`

--- a/src/components/KRLogoKR.tsx
+++ b/src/components/KRLogoKR.tsx
@@ -1,37 +1,8 @@
 "use client";
 import { motion } from "framer-motion";
-import { createPortal } from "react-dom";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
-type Intensity = "strong" | "max"; // "max" = plus visible (par défaut)
-
-function usePortalTooltip(label: string) {
-  const anchorRef = useRef<HTMLAnchorElement | null>(null);
-  const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
-
-  const update = () => {
-    const el = anchorRef.current; if (!el) return;
-    const r = el.getBoundingClientRect();
-    setPos({ x: r.left + r.width / 2, y: r.bottom });
-  };
-
-  const Tooltip = () =>
-    typeof document !== "undefined" && open && pos
-      ? createPortal(
-          <div
-            role="tooltip"
-            className="fixed z-50 px-2 py-1 rounded bg-black text-white text-xs pointer-events-none shadow"
-            style={{ left: pos.x, top: pos.y + 10, transform: "translateX(-50%)" }}
-          >
-            {label}
-          </div>,
-          document.body
-        )
-      : null;
-
-  return { anchorRef, open, setOpen, update, Tooltip };
-}
+type Intensity = "strong" | "max";
 
 function variantsFor(intensity: Intensity) {
   const cfg = intensity === "max"
@@ -39,9 +10,9 @@ function variantsFor(intensity: Intensity) {
     : { y: 6, rot: 4, scale: 1.08, dur: 2.8 };
   return {
     animate: {
-      y: [0, -cfg.y, 0, cfg.y, 0],             // bob
-      rotate: [0, cfg.rot, 0, -cfg.rot, 0],    // tilt
-      scale: [1, cfg.scale, 1, cfg.scale, 1],  // pulse
+      y: [0, -cfg.y, 0, cfg.y, 0],
+      rotate: [0, cfg.rot, 0, -cfg.rot, 0],
+      scale: [1, cfg.scale, 1, cfg.scale, 1],
       transition: { duration: cfg.dur, repeat: Infinity, ease: "easeInOut" }
     },
     whileHover: { scale: cfg.scale + 0.04, transition: { duration: 0.2 } },
@@ -53,35 +24,19 @@ export default function KRLogoKR({
   hrefK,
   hrefR,
   className = "",
-  intensity = "max" as Intensity, // Mouvement BIEN visible par défaut
+  intensity = "max" as Intensity,
 }: {
   hrefK?: string;
   hrefR?: string;
   className?: string;
   intensity?: Intensity;
 }) {
-  // tooltips exclusives : une seule à la fois
-  const k = usePortalTooltip("Portfolio de Karim");
-  const r = usePortalTooltip("Portfolio de Raphaël");
-  const [exclusive, setExclusive] = useState<"K" | "R" | null>(null);
-
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    const on = () => { k.update(); r.update(); };
-    window.addEventListener("resize", on);
-    window.addEventListener("scroll", on, { passive: true });
-    return () => { window.removeEventListener("resize", on); window.removeEventListener("scroll", on); };
-  }, []);
-  /* eslint-enable react-hooks/exhaustive-deps */
-
   const vK = variantsFor(intensity);
   const vR = variantsFor(intensity);
 
   return (
     <span className={`relative flex items-center gap-1 font-bold text-sm md:text-base ${className}`}>
-      {/* K (phase 0) */}
       <motion.a
-        ref={k.anchorRef}
         href={hrefK}
         target="_blank"
         rel="noopener noreferrer"
@@ -90,19 +45,13 @@ export default function KRLogoKR({
         animate="animate"
         whileHover="whileHover"
         whileTap="whileTap"
-        onMouseEnter={() => { setExclusive("K"); k.setOpen(true); k.update(); }}
-        onFocus={() => { setExclusive("K"); k.setOpen(true); k.update(); }}
-        onMouseLeave={() => { if (exclusive === "K") { k.setOpen(false); setExclusive(null); } }}
-        onBlur={() => { if (exclusive === "K") { k.setOpen(false); setExclusive(null); } }}
       >
         K
       </motion.a>
 
       <span aria-hidden>/</span>
 
-      {/* R (phase décalée) */}
       <motion.a
-        ref={r.anchorRef}
         href={hrefR}
         target="_blank"
         rel="noopener noreferrer"
@@ -111,21 +60,12 @@ export default function KRLogoKR({
         animate="animate"
         whileHover="whileHover"
         whileTap="whileTap"
-        transition={{ delay: 0.6 }}  // décalage pour capter l’œil
-        onMouseEnter={() => { setExclusive("R"); r.setOpen(true); r.update(); }}
-        onFocus={() => { setExclusive("R"); r.setOpen(true); r.update(); }}
-        onMouseLeave={() => { if (exclusive === "R") { r.setOpen(false); setExclusive(null); } }}
-        onBlur={() => { if (exclusive === "R") { r.setOpen(false); setExclusive(null); } }}
+        transition={{ delay: 0.6 }}
       >
         R
       </motion.a>
 
-      {/* Tooltips exclusives via Portal (jamais coupées par le header) */}
-      {exclusive === "K" && <k.Tooltip />}
-      {exclusive === "R" && <r.Tooltip />}
-
-      {/* Respect des utilisateurs sensibles au mouvement */}
-      <style jsx global>{`
+      <style>{`
         @media (prefers-reduced-motion: reduce) {
           *[data-framer-motion] { animation: none !important; transition: none !important; transform: none !important; }
         }

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -8,7 +8,8 @@ interface Project {
   tagline: string;
   description: string;
   tags: string[];
-  url: string;
+  siteUrl: string;
+  githubUrl?: string;
   status: string;
 }
 
@@ -17,23 +18,24 @@ const content: Record<Language, { label: string; projects: Project[] }> = {
     label: 'Projets en cours',
     projects: [
       {
-        id: 'landing10cheap',
-        name: 'Landing 10€',
-        tagline: 'Sites web clé en main à 9,99€',
+        id: 'siteeasy',
+        name: 'SiteEasy',
+        tagline: 'Un site web professionnel à 9,99€',
         description:
-          'Une plateforme de vente complète pour commander un site web en quelques clics. Tunnel de vente, paiement Stripe, emails automatisés et livraison manuelle via guide PDF.',
+          'Plateforme clé en main pour commander un site web en quelques clics. Tunnel de vente automatisé, paiement Stripe sécurisé, confirmation email instantanée et livraison manuelle avec guide PDF.',
         tags: ['Next.js', 'Stripe', 'Supabase', 'Resend'],
-        url: 'https://github.com/KRGlobalLTD/Landing10cheap',
+        siteUrl: 'https://siteeasy.krglobalsolutionsltd.com/',
+        githubUrl: 'https://github.com/KRGlobalLTD/Landing10cheap',
         status: 'Live',
       },
       {
         id: 'kr-agents',
         name: 'KR Global Agents',
-        tagline: '28 agents IA orchestrés',
+        tagline: "Système d'exploitation IA pour l'entreprise",
         description:
-          "Un système multi-agents piloté par l'IA pour automatiser des workflows complexes, augmenter la productivité et déléguer des tâches répétitives à des agents spécialisés.",
-        tags: ['Next.js', 'Claude AI', 'TypeScript', 'PostgreSQL'],
-        url: 'https://github.com/KRGlobalLTD/kr-global-agents',
+          '28 agents IA spécialisés orchestrés sur une base Supabase centralisée : finances, clients, marketing, réseaux sociaux, comptabilité, prospects, automatisations WhatsApp et bien plus.',
+        tags: ['Next.js', 'Claude AI', 'Supabase', 'TypeScript'],
+        siteUrl: 'https://github.com/KRGlobalLTD/kr-global-agents',
         status: 'En cours',
       },
     ],
@@ -42,23 +44,24 @@ const content: Record<Language, { label: string; projects: Project[] }> = {
     label: 'Current projects',
     projects: [
       {
-        id: 'landing10cheap',
-        name: 'Landing 10€',
-        tagline: 'Turnkey websites at €9.99',
+        id: 'siteeasy',
+        name: 'SiteEasy',
+        tagline: 'A professional website for €9.99',
         description:
-          'A complete sales platform to order a website in a few clicks. Sales funnel, Stripe payment, automated emails, and manual delivery with a PDF guide.',
+          'Turnkey platform to order a website in a few clicks. Automated sales funnel, secure Stripe payment, instant email confirmation, and manual delivery with a PDF guide.',
         tags: ['Next.js', 'Stripe', 'Supabase', 'Resend'],
-        url: 'https://github.com/KRGlobalLTD/Landing10cheap',
+        siteUrl: 'https://siteeasy.krglobalsolutionsltd.com/',
+        githubUrl: 'https://github.com/KRGlobalLTD/Landing10cheap',
         status: 'Live',
       },
       {
         id: 'kr-agents',
         name: 'KR Global Agents',
-        tagline: '28 orchestrated AI agents',
+        tagline: 'AI operating system for business',
         description:
-          'An AI-powered multi-agent system to automate complex workflows, boost team productivity, and delegate repetitive tasks to specialized agents.',
-        tags: ['Next.js', 'Claude AI', 'TypeScript', 'PostgreSQL'],
-        url: 'https://github.com/KRGlobalLTD/kr-global-agents',
+          '28 specialized AI agents orchestrated on a centralized Supabase database: finance, clients, marketing, social media, accounting, prospects, WhatsApp automations and more.',
+        tags: ['Next.js', 'Claude AI', 'Supabase', 'TypeScript'],
+        siteUrl: 'https://github.com/KRGlobalLTD/kr-global-agents',
         status: 'In progress',
       },
     ],
@@ -69,11 +72,11 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
   const c = content[lang];
 
   return (
-    <section id="projects" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
+    <section id="projects" className="py-24 sm:py-32 border-t border-neutral-100 bg-white">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
 
         <motion.p
-          className="text-[10px] uppercase tracking-[0.28em] text-neutral-600 mb-14"
+          className="text-[10px] uppercase tracking-[0.28em] text-neutral-400 mb-14"
           initial={{ opacity: 0 }}
           whileInView={{ opacity: 1 }}
           viewport={{ once: true }}
@@ -82,52 +85,75 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
           {c.label}
         </motion.p>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-white/[0.06]">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-neutral-100">
           {c.projects.map((project, i) => (
-            <motion.a
+            <motion.div
               key={project.id}
-              href={project.url}
-              target="_blank"
-              rel="noreferrer"
               initial={{ opacity: 0, y: 24 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: i * 0.12, duration: 0.6 }}
-              className="group block bg-black p-8 sm:p-12 hover:bg-[#0a0a0a] transition-colors"
+              className="bg-white p-8 sm:p-12"
             >
-              <div className="flex items-center justify-between mb-10">
-                <span className="text-[10px] uppercase tracking-widest text-neutral-600">
+              <div className="flex items-center justify-between mb-8">
+                <span className="text-[10px] uppercase tracking-widest text-neutral-400 border border-neutral-200 rounded-full px-3 py-1">
                   {project.status}
                 </span>
-                <ExternalLink
-                  size={14}
-                  className="text-neutral-700 group-hover:text-white transition-colors"
-                />
+                <a
+                  href={project.siteUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 text-xs text-neutral-400 hover:text-black transition-colors"
+                  aria-label={`Visiter ${project.name}`}
+                >
+                  <ExternalLink size={13} />
+                </a>
               </div>
 
               <h3
-                className="font-bold tracking-tight text-white leading-[0.95]"
+                className="font-bold tracking-tight text-black leading-[0.95]"
                 style={{ fontSize: 'clamp(2rem, 4vw, 3rem)' }}
               >
                 {project.name}
               </h3>
               <p className="mt-3 text-neutral-500 text-base">{project.tagline}</p>
 
-              <p className="mt-5 text-sm text-neutral-600 leading-relaxed">
+              <p className="mt-5 text-sm text-neutral-500 leading-relaxed">
                 {project.description}
               </p>
 
-              <div className="mt-10 flex flex-wrap gap-2">
+              <div className="mt-8 flex flex-wrap gap-2">
                 {project.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="text-[10px] uppercase tracking-wider border border-white/10 rounded-full px-3 py-1 text-neutral-600 group-hover:border-white/20 transition-colors"
+                    className="text-[10px] uppercase tracking-wider border border-neutral-200 rounded-full px-3 py-1 text-neutral-500"
                   >
                     {tag}
                   </span>
                 ))}
               </div>
-            </motion.a>
+
+              <div className="mt-8 flex gap-4 text-xs">
+                <a
+                  href={project.siteUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium border-b border-black pb-px hover:opacity-50 transition-opacity"
+                >
+                  {lang === 'fr' ? 'Voir le site →' : 'Visit site →'}
+                </a>
+                {project.githubUrl && (
+                  <a
+                    href={project.githubUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-neutral-400 border-b border-neutral-300 pb-px hover:text-black hover:border-black transition-colors"
+                  >
+                    GitHub
+                  </a>
+                )}
+              </div>
+            </motion.div>
           ))}
         </div>
 

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,5 +1,4 @@
 import { motion } from 'framer-motion';
-import { ExternalLink } from 'lucide-react';
 import type { Language } from '../data/translations';
 
 interface Project {
@@ -95,20 +94,9 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
               transition={{ delay: i * 0.12, duration: 0.6 }}
               className="bg-white p-8 sm:p-12 group"
             >
-              <div className="flex items-center justify-between mb-10">
-                <span className="text-[10px] uppercase tracking-widest text-neutral-400">
-                  {project.status}
-                </span>
-                <a
-                  href={project.siteUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-neutral-400 hover:text-black transition-colors"
-                  aria-label={`Visiter ${project.name}`}
-                >
-                  <ExternalLink size={14} />
-                </a>
-              </div>
+              <span className="text-[10px] uppercase tracking-widest text-neutral-400 block mb-10">
+                {project.status}
+              </span>
 
               <h3
                 className="font-bold tracking-tight text-black leading-[0.95]"
@@ -122,36 +110,15 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
                 {project.description}
               </p>
 
-              <div className="mt-8 flex flex-wrap gap-2">
-                {project.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="text-[10px] uppercase tracking-wider border border-black/10 rounded-full px-3 py-1 text-neutral-500"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-
-              <div className="mt-8 flex gap-5 text-xs">
+              <div className="mt-8">
                 <a
                   href={project.siteUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-black border-b border-black/20 pb-px hover:border-black transition-colors"
+                  className="text-xs text-black border-b border-black/20 pb-px hover:border-black transition-colors"
                 >
                   {lang === 'fr' ? 'Voir le site →' : 'Visit site →'}
                 </a>
-                {project.githubUrl && (
-                  <a
-                    href={project.githubUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-neutral-400 border-b border-neutral-300 pb-px hover:text-neutral-700 hover:border-neutral-500 transition-colors"
-                  >
-                    GitHub
-                  </a>
-                )}
               </div>
             </motion.div>
           ))}

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -69,11 +69,11 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
   const c = content[lang];
 
   return (
-    <section id="projects" className="py-24 sm:py-32 border-t border-neutral-100">
+    <section id="projects" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
 
         <motion.p
-          className="text-xs uppercase tracking-[0.22em] text-neutral-400 mb-14"
+          className="text-[10px] uppercase tracking-[0.28em] text-neutral-600 mb-14"
           initial={{ opacity: 0 }}
           whileInView={{ opacity: 1 }}
           viewport={{ once: true }}
@@ -82,7 +82,7 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
           {c.label}
         </motion.p>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-white/[0.06]">
           {c.projects.map((project, i) => (
             <motion.a
               key={project.id}
@@ -93,32 +93,35 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: i * 0.12, duration: 0.6 }}
-              className="group block rounded-2xl border border-neutral-200 p-8 sm:p-10 hover:border-neutral-900 transition-all duration-200"
+              className="group block bg-black p-8 sm:p-12 hover:bg-[#0a0a0a] transition-colors"
             >
-              <div className="flex items-center justify-between mb-8">
-                <span className="text-[10px] uppercase tracking-widest text-neutral-400 border border-neutral-200 rounded-full px-3 py-1">
+              <div className="flex items-center justify-between mb-10">
+                <span className="text-[10px] uppercase tracking-widest text-neutral-600">
                   {project.status}
                 </span>
                 <ExternalLink
-                  size={15}
-                  className="text-neutral-300 group-hover:text-neutral-900 transition-colors"
+                  size={14}
+                  className="text-neutral-700 group-hover:text-white transition-colors"
                 />
               </div>
 
-              <h3 className="text-3xl sm:text-4xl font-bold tracking-tight">
+              <h3
+                className="font-bold tracking-tight text-white leading-[0.95]"
+                style={{ fontSize: 'clamp(2rem, 4vw, 3rem)' }}
+              >
                 {project.name}
               </h3>
-              <p className="mt-2 text-neutral-500 text-lg">{project.tagline}</p>
+              <p className="mt-3 text-neutral-500 text-base">{project.tagline}</p>
 
-              <p className="mt-5 text-sm text-neutral-500 leading-relaxed">
+              <p className="mt-5 text-sm text-neutral-600 leading-relaxed">
                 {project.description}
               </p>
 
-              <div className="mt-8 flex flex-wrap gap-2">
+              <div className="mt-10 flex flex-wrap gap-2">
                 {project.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="text-xs border border-neutral-200 rounded-full px-3 py-1 text-neutral-500"
+                    className="text-[10px] uppercase tracking-wider border border-white/10 rounded-full px-3 py-1 text-neutral-600 group-hover:border-white/20 transition-colors"
                   >
                     {tag}
                   </span>
@@ -127,6 +130,7 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
             </motion.a>
           ))}
         </div>
+
       </div>
     </section>
   );

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -33,7 +33,7 @@ const content: Record<Language, { label: string; projects: Project[] }> = {
         name: 'KR Global Agents',
         tagline: "Système d'exploitation IA pour l'entreprise",
         description:
-          '28 agents IA spécialisés orchestrés sur une base Supabase centralisée : finances, clients, marketing, réseaux sociaux, comptabilité, prospects, automatisations WhatsApp et bien plus.',
+          '28 agents IA spécialisés sur une base Supabase centralisée : finances, clients, marketing, réseaux sociaux, comptabilité, prospects, automations WhatsApp et bien plus.',
         tags: ['Next.js', 'Claude AI', 'Supabase', 'TypeScript'],
         siteUrl: 'https://github.com/KRGlobalLTD/kr-global-agents',
         status: 'En cours',
@@ -59,7 +59,7 @@ const content: Record<Language, { label: string; projects: Project[] }> = {
         name: 'KR Global Agents',
         tagline: 'AI operating system for business',
         description:
-          '28 specialized AI agents orchestrated on a centralized Supabase database: finance, clients, marketing, social media, accounting, prospects, WhatsApp automations and more.',
+          '28 specialized AI agents on a centralized Supabase database: finance, clients, marketing, social media, accounting, prospects, WhatsApp automations and more.',
         tags: ['Next.js', 'Claude AI', 'Supabase', 'TypeScript'],
         siteUrl: 'https://github.com/KRGlobalLTD/kr-global-agents',
         status: 'In progress',
@@ -72,11 +72,11 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
   const c = content[lang];
 
   return (
-    <section id="projects" className="py-24 sm:py-32 border-t border-neutral-100 bg-white">
+    <section id="projects" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
 
         <motion.p
-          className="text-[10px] uppercase tracking-[0.28em] text-neutral-400 mb-14"
+          className="text-[10px] uppercase tracking-[0.28em] text-neutral-600 mb-14"
           initial={{ opacity: 0 }}
           whileInView={{ opacity: 1 }}
           viewport={{ once: true }}
@@ -85,7 +85,7 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
           {c.label}
         </motion.p>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-neutral-100">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-white/[0.05]">
           {c.projects.map((project, i) => (
             <motion.div
               key={project.id}
@@ -93,32 +93,32 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: i * 0.12, duration: 0.6 }}
-              className="bg-white p-8 sm:p-12"
+              className="bg-black p-8 sm:p-12 group"
             >
-              <div className="flex items-center justify-between mb-8">
-                <span className="text-[10px] uppercase tracking-widest text-neutral-400 border border-neutral-200 rounded-full px-3 py-1">
+              <div className="flex items-center justify-between mb-10">
+                <span className="text-[10px] uppercase tracking-widest text-neutral-600">
                   {project.status}
                 </span>
                 <a
                   href={project.siteUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="inline-flex items-center gap-1.5 text-xs text-neutral-400 hover:text-black transition-colors"
+                  className="text-neutral-700 hover:text-white transition-colors"
                   aria-label={`Visiter ${project.name}`}
                 >
-                  <ExternalLink size={13} />
+                  <ExternalLink size={14} />
                 </a>
               </div>
 
               <h3
-                className="font-bold tracking-tight text-black leading-[0.95]"
+                className="font-bold tracking-tight text-white leading-[0.95]"
                 style={{ fontSize: 'clamp(2rem, 4vw, 3rem)' }}
               >
                 {project.name}
               </h3>
               <p className="mt-3 text-neutral-500 text-base">{project.tagline}</p>
 
-              <p className="mt-5 text-sm text-neutral-500 leading-relaxed">
+              <p className="mt-5 text-sm text-neutral-600 leading-relaxed">
                 {project.description}
               </p>
 
@@ -126,19 +126,19 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
                 {project.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="text-[10px] uppercase tracking-wider border border-neutral-200 rounded-full px-3 py-1 text-neutral-500"
+                    className="text-[10px] uppercase tracking-wider border border-white/10 rounded-full px-3 py-1 text-neutral-600"
                   >
                     {tag}
                   </span>
                 ))}
               </div>
 
-              <div className="mt-8 flex gap-4 text-xs">
+              <div className="mt-8 flex gap-5 text-xs">
                 <a
                   href={project.siteUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="font-medium border-b border-black pb-px hover:opacity-50 transition-opacity"
+                  className="text-white border-b border-white/20 pb-px hover:border-white transition-colors"
                 >
                   {lang === 'fr' ? 'Voir le site →' : 'Visit site →'}
                 </a>
@@ -147,7 +147,7 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
                     href={project.githubUrl}
                     target="_blank"
                     rel="noreferrer"
-                    className="text-neutral-400 border-b border-neutral-300 pb-px hover:text-black hover:border-black transition-colors"
+                    className="text-neutral-600 border-b border-neutral-700 pb-px hover:text-neutral-300 hover:border-neutral-400 transition-colors"
                   >
                     GitHub
                   </a>

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,0 +1,133 @@
+import { motion } from 'framer-motion';
+import { ExternalLink } from 'lucide-react';
+import type { Language } from '../data/translations';
+
+interface Project {
+  id: string;
+  name: string;
+  tagline: string;
+  description: string;
+  tags: string[];
+  url: string;
+  status: string;
+}
+
+const content: Record<Language, { label: string; projects: Project[] }> = {
+  fr: {
+    label: 'Projets en cours',
+    projects: [
+      {
+        id: 'landing10cheap',
+        name: 'Landing 10€',
+        tagline: 'Sites web clé en main à 9,99€',
+        description:
+          'Une plateforme de vente complète pour commander un site web en quelques clics. Tunnel de vente, paiement Stripe, emails automatisés et livraison manuelle via guide PDF.',
+        tags: ['Next.js', 'Stripe', 'Supabase', 'Resend'],
+        url: 'https://github.com/KRGlobalLTD/Landing10cheap',
+        status: 'Live',
+      },
+      {
+        id: 'kr-agents',
+        name: 'KR Global Agents',
+        tagline: '28 agents IA orchestrés',
+        description:
+          "Un système multi-agents piloté par l'IA pour automatiser des workflows complexes, augmenter la productivité et déléguer des tâches répétitives à des agents spécialisés.",
+        tags: ['Next.js', 'Claude AI', 'TypeScript', 'PostgreSQL'],
+        url: 'https://github.com/KRGlobalLTD/kr-global-agents',
+        status: 'En cours',
+      },
+    ],
+  },
+  en: {
+    label: 'Current projects',
+    projects: [
+      {
+        id: 'landing10cheap',
+        name: 'Landing 10€',
+        tagline: 'Turnkey websites at €9.99',
+        description:
+          'A complete sales platform to order a website in a few clicks. Sales funnel, Stripe payment, automated emails, and manual delivery with a PDF guide.',
+        tags: ['Next.js', 'Stripe', 'Supabase', 'Resend'],
+        url: 'https://github.com/KRGlobalLTD/Landing10cheap',
+        status: 'Live',
+      },
+      {
+        id: 'kr-agents',
+        name: 'KR Global Agents',
+        tagline: '28 orchestrated AI agents',
+        description:
+          'An AI-powered multi-agent system to automate complex workflows, boost team productivity, and delegate repetitive tasks to specialized agents.',
+        tags: ['Next.js', 'Claude AI', 'TypeScript', 'PostgreSQL'],
+        url: 'https://github.com/KRGlobalLTD/kr-global-agents',
+        status: 'In progress',
+      },
+    ],
+  },
+};
+
+export default function ProjectsSection({ lang }: { lang: Language }) {
+  const c = content[lang];
+
+  return (
+    <section id="projects" className="py-24 sm:py-32 border-t border-neutral-100">
+      <div className="container mx-auto px-4 sm:px-6 md:px-8">
+
+        <motion.p
+          className="text-xs uppercase tracking-[0.22em] text-neutral-400 mb-14"
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+        >
+          {c.label}
+        </motion.p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {c.projects.map((project, i) => (
+            <motion.a
+              key={project.id}
+              href={project.url}
+              target="_blank"
+              rel="noreferrer"
+              initial={{ opacity: 0, y: 24 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.12, duration: 0.6 }}
+              className="group block rounded-2xl border border-neutral-200 p-8 sm:p-10 hover:border-neutral-900 transition-all duration-200"
+            >
+              <div className="flex items-center justify-between mb-8">
+                <span className="text-[10px] uppercase tracking-widest text-neutral-400 border border-neutral-200 rounded-full px-3 py-1">
+                  {project.status}
+                </span>
+                <ExternalLink
+                  size={15}
+                  className="text-neutral-300 group-hover:text-neutral-900 transition-colors"
+                />
+              </div>
+
+              <h3 className="text-3xl sm:text-4xl font-bold tracking-tight">
+                {project.name}
+              </h3>
+              <p className="mt-2 text-neutral-500 text-lg">{project.tagline}</p>
+
+              <p className="mt-5 text-sm text-neutral-500 leading-relaxed">
+                {project.description}
+              </p>
+
+              <div className="mt-8 flex flex-wrap gap-2">
+                {project.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="text-xs border border-neutral-200 rounded-full px-3 py-1 text-neutral-500"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </motion.a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -35,7 +35,7 @@ const content: Record<Language, { label: string; projects: Project[] }> = {
         description:
           '28 agents IA spécialisés sur une base Supabase centralisée : finances, clients, marketing, réseaux sociaux, comptabilité, prospects, automations WhatsApp et bien plus.',
         tags: ['Next.js', 'Claude AI', 'Supabase', 'TypeScript'],
-        siteUrl: 'https://github.com/KRGlobalLTD/kr-global-agents',
+        siteUrl: 'https://kr-global-agents.vercel.app/',
         status: 'En cours',
       },
     ],
@@ -61,7 +61,7 @@ const content: Record<Language, { label: string; projects: Project[] }> = {
         description:
           '28 specialized AI agents on a centralized Supabase database: finance, clients, marketing, social media, accounting, prospects, WhatsApp automations and more.',
         tags: ['Next.js', 'Claude AI', 'Supabase', 'TypeScript'],
-        siteUrl: 'https://github.com/KRGlobalLTD/kr-global-agents',
+        siteUrl: 'https://kr-global-agents.vercel.app/',
         status: 'In progress',
       },
     ],
@@ -72,11 +72,11 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
   const c = content[lang];
 
   return (
-    <section id="projects" className="py-24 sm:py-32 bg-black border-t border-white/[0.06]">
+    <section id="projects" className="py-24 sm:py-32 bg-white border-t border-black/[0.06]">
       <div className="container mx-auto px-4 sm:px-6 md:px-8">
 
         <motion.p
-          className="text-[10px] uppercase tracking-[0.28em] text-neutral-600 mb-14"
+          className="text-[10px] uppercase tracking-[0.28em] text-neutral-400 mb-14"
           initial={{ opacity: 0 }}
           whileInView={{ opacity: 1 }}
           viewport={{ once: true }}
@@ -85,7 +85,7 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
           {c.label}
         </motion.p>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-white/[0.05]">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-black/[0.06]">
           {c.projects.map((project, i) => (
             <motion.div
               key={project.id}
@@ -93,17 +93,17 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: i * 0.12, duration: 0.6 }}
-              className="bg-black p-8 sm:p-12 group"
+              className="bg-white p-8 sm:p-12 group"
             >
               <div className="flex items-center justify-between mb-10">
-                <span className="text-[10px] uppercase tracking-widest text-neutral-600">
+                <span className="text-[10px] uppercase tracking-widest text-neutral-400">
                   {project.status}
                 </span>
                 <a
                   href={project.siteUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-neutral-700 hover:text-white transition-colors"
+                  className="text-neutral-400 hover:text-black transition-colors"
                   aria-label={`Visiter ${project.name}`}
                 >
                   <ExternalLink size={14} />
@@ -111,14 +111,14 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
               </div>
 
               <h3
-                className="font-bold tracking-tight text-white leading-[0.95]"
+                className="font-bold tracking-tight text-black leading-[0.95]"
                 style={{ fontSize: 'clamp(2rem, 4vw, 3rem)' }}
               >
                 {project.name}
               </h3>
               <p className="mt-3 text-neutral-500 text-base">{project.tagline}</p>
 
-              <p className="mt-5 text-sm text-neutral-600 leading-relaxed">
+              <p className="mt-5 text-sm text-neutral-500 leading-relaxed">
                 {project.description}
               </p>
 
@@ -126,7 +126,7 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
                 {project.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="text-[10px] uppercase tracking-wider border border-white/10 rounded-full px-3 py-1 text-neutral-600"
+                    className="text-[10px] uppercase tracking-wider border border-black/10 rounded-full px-3 py-1 text-neutral-500"
                   >
                     {tag}
                   </span>
@@ -138,7 +138,7 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
                   href={project.siteUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-white border-b border-white/20 pb-px hover:border-white transition-colors"
+                  className="text-black border-b border-black/20 pb-px hover:border-black transition-colors"
                 >
                   {lang === 'fr' ? 'Voir le site →' : 'Visit site →'}
                 </a>
@@ -147,7 +147,7 @@ export default function ProjectsSection({ lang }: { lang: Language }) {
                     href={project.githubUrl}
                     target="_blank"
                     rel="noreferrer"
-                    className="text-neutral-600 border-b border-neutral-700 pb-px hover:text-neutral-300 hover:border-neutral-400 transition-colors"
+                    className="text-neutral-400 border-b border-neutral-300 pb-px hover:text-neutral-700 hover:border-neutral-500 transition-colors"
                   >
                     GitHub
                   </a>

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -15,17 +15,39 @@ export const socialLinks = [
 
 export default function SocialLinks({
   className,
-  size = 24,
+  size = 16,
   variant = "header",
 }: {
   className?: string;
   size?: number;
   variant?: Variant;
 }) {
-  const spacing = variant === "header" ? "gap-3 sm:gap-4" : "gap-4 sm:gap-5";
-  const item = "inline-flex items-center justify-center min-w-[44px] min-h-[44px]";
+  const isFooter = variant === "footer";
+
+  if (isFooter) {
+    return (
+      <nav aria-label="Réseaux sociaux" className={`flex flex-wrap gap-5 ${className || ""}`}>
+        {socialLinks.map((link) => (
+          <a
+            key={link.id}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={link.label}
+            className="flex items-center gap-1.5 text-xs text-neutral-500 hover:text-black transition-colors group"
+          >
+            <span className="opacity-60 group-hover:opacity-100 transition-opacity">
+              {link.icon(13)}
+            </span>
+            {link.label}
+          </a>
+        ))}
+      </nav>
+    );
+  }
+
   return (
-    <nav aria-label="Réseaux sociaux" className={`flex flex-wrap ${spacing} ${className || ""}`}>
+    <nav aria-label="Réseaux sociaux" className={`flex items-center gap-4 ${className || ""}`}>
       {socialLinks.map((link) => (
         <a
           key={link.id}
@@ -33,7 +55,7 @@ export default function SocialLinks({
           target="_blank"
           rel="noopener noreferrer"
           aria-label={link.label}
-          className={item}
+          className="text-neutral-400 hover:text-black transition-colors"
         >
           {link.icon(size)}
         </a>

--- a/src/components/faq/FAQAccordion.tsx
+++ b/src/components/faq/FAQAccordion.tsx
@@ -1,17 +1,12 @@
 "use client";
 import React, { useMemo } from "react";
 import { faqFR, faqEN, QA } from "@/data/faq";
-
-// Optionnel : si le projet expose un hook de langue globale, on l'utilise sans casser le build
-// Essaie d'importer l'un de ces hooks ; si non présent, ignore proprement.
-// import { useTranslation } from "react-i18next";
 import { useLanguage } from "@/hooks/useLanguage";
 
 type Props = { locale?: "fr" | "en"; className?: string };
 
 function Item({ qa, idx }: { qa: QA; idx: number }) {
   const id = `faq-${idx}`;
-  // On s'appuie sur <details> natif + event onToggle pour connaître l'état ouvert/fermé
   const [open, setOpen] = React.useState(false);
   const onToggle = (e: React.SyntheticEvent<HTMLDetailsElement>) => {
     setOpen((e.currentTarget as HTMLDetailsElement).open);
@@ -20,19 +15,22 @@ function Item({ qa, idx }: { qa: QA; idx: number }) {
   return (
     <details
       onToggle={onToggle}
-      className="border-b border-neutral-100 py-4 md:py-5"
+      className="border-b border-white/[0.07] py-5"
     >
       <summary
-        className="cursor-pointer list-none select-none flex items-center justify-between gap-3 text-base md:text-lg font-medium"
+        className="cursor-pointer list-none select-none flex items-center justify-between gap-3 text-sm md:text-base font-medium text-white"
         aria-controls={`${id}-panel`}
         aria-expanded={open}
       >
         <span>{qa.q}</span>
-        <span aria-hidden className="inline-flex h-7 w-7 items-center justify-center rounded-full border">
+        <span
+          aria-hidden
+          className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-white/20 text-white/60 shrink-0 text-xs"
+        >
           {open ? "–" : "+"}
         </span>
       </summary>
-      <div id={`${id}-panel`} className="pt-3 text-sm md:text-base opacity-90">
+      <div id={`${id}-panel`} className="pt-4 text-sm text-neutral-500 leading-relaxed">
         {qa.a}
       </div>
     </details>
@@ -40,19 +38,17 @@ function Item({ qa, idx }: { qa: QA; idx: number }) {
 }
 
 export default function FAQAccordion({ locale = "fr", className }: Props) {
-  // 1) Source de vérité = langue globale si dispo, sinon prop locale
   const { currentLanguage } = useLanguage();
   const currentLocale: "fr" | "en" = currentLanguage === "en" ? "en" : locale;
-
   const data = useMemo(() => (currentLocale === "en" ? faqEN : faqFR), [currentLocale]);
 
   return (
     <section id="faq" aria-labelledby="faq-title" className={["w-full", className].filter(Boolean).join(" ")}>
-      <div className="max-w-6xl mx-auto px-4 md:px-6">
-        <header className="mb-5 md:mb-7">
-          <h2 id="faq-title" className="text-3xl md:text-4xl font-bold text-black">FAQ</h2>
-        </header>
-        <div className="space-y-3 md:space-y-4">
+      <div className="max-w-3xl">
+        <h2 id="faq-title" className="text-3xl md:text-4xl font-bold text-white mb-10">
+          FAQ
+        </h2>
+        <div>
           {data.map((qa, i) => (
             <Item key={i} qa={qa} idx={i} />
           ))}
@@ -61,4 +57,3 @@ export default function FAQAccordion({ locale = "fr", className }: Props) {
     </section>
   );
 }
-

--- a/src/components/faq/FAQAccordion.tsx
+++ b/src/components/faq/FAQAccordion.tsx
@@ -15,17 +15,17 @@ function Item({ qa, idx }: { qa: QA; idx: number }) {
   return (
     <details
       onToggle={onToggle}
-      className="border-b border-white/[0.07] py-5"
+      className="border-b border-black/[0.08] py-5"
     >
       <summary
-        className="cursor-pointer list-none select-none flex items-center justify-between gap-3 text-sm md:text-base font-medium text-white"
+        className="cursor-pointer list-none select-none flex items-center justify-between gap-3 text-sm md:text-base font-medium text-black"
         aria-controls={`${id}-panel`}
         aria-expanded={open}
       >
         <span>{qa.q}</span>
         <span
           aria-hidden
-          className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-white/20 text-white/60 shrink-0 text-xs"
+          className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-black/20 text-black/50 shrink-0 text-xs"
         >
           {open ? "–" : "+"}
         </span>
@@ -45,7 +45,7 @@ export default function FAQAccordion({ locale = "fr", className }: Props) {
   return (
     <section id="faq" aria-labelledby="faq-title" className={["w-full", className].filter(Boolean).join(" ")}>
       <div className="max-w-3xl">
-        <h2 id="faq-title" className="text-3xl md:text-4xl font-bold text-white mb-10">
+        <h2 id="faq-title" className="text-3xl md:text-4xl font-bold text-black mb-10">
           FAQ
         </h2>
         <div>

--- a/src/components/faq/FAQAccordion.tsx
+++ b/src/components/faq/FAQAccordion.tsx
@@ -20,7 +20,7 @@ function Item({ qa, idx }: { qa: QA; idx: number }) {
   return (
     <details
       onToggle={onToggle}
-      className="rounded-2xl border bg-white/60 dark:bg-zinc-900/60 p-4 md:p-5"
+      className="border-b border-neutral-100 py-4 md:py-5"
     >
       <summary
         className="cursor-pointer list-none select-none flex items-center justify-between gap-3 text-base md:text-lg font-medium"
@@ -50,7 +50,7 @@ export default function FAQAccordion({ locale = "fr", className }: Props) {
     <section id="faq" aria-labelledby="faq-title" className={["w-full", className].filter(Boolean).join(" ")}>
       <div className="max-w-6xl mx-auto px-4 md:px-6">
         <header className="mb-5 md:mb-7">
-          <h2 id="faq-title" className="text-3xl md:text-4xl font-extrabold">FAQ</h2>
+          <h2 id="faq-title" className="text-3xl md:text-4xl font-bold text-black">FAQ</h2>
         </header>
         <div className="space-y-3 md:space-y-4">
           {data.map((qa, i) => (

--- a/src/components/three/FloatingShape.tsx
+++ b/src/components/three/FloatingShape.tsx
@@ -4,42 +4,36 @@ import * as THREE from 'three';
 
 function OuterCube() {
   const ref = useRef<THREE.LineSegments>(null);
-
   useFrame(({ clock }) => {
     if (!ref.current) return;
     ref.current.rotation.x = clock.elapsedTime * 0.09;
     ref.current.rotation.y = clock.elapsedTime * 0.14;
   });
-
   const edges = useMemo(
     () => new THREE.EdgesGeometry(new THREE.BoxGeometry(2.4, 2.4, 2.4)),
     []
   );
-
   return (
     <lineSegments ref={ref} geometry={edges}>
-      <lineBasicMaterial color="#ffffff" />
+      <lineBasicMaterial color="#000000" />
     </lineSegments>
   );
 }
 
 function InnerCube() {
   const ref = useRef<THREE.LineSegments>(null);
-
   useFrame(({ clock }) => {
     if (!ref.current) return;
     ref.current.rotation.x = -clock.elapsedTime * 0.06;
     ref.current.rotation.y = -clock.elapsedTime * 0.10;
   });
-
   const edges = useMemo(
     () => new THREE.EdgesGeometry(new THREE.BoxGeometry(1.3, 1.3, 1.3)),
     []
   );
-
   return (
     <lineSegments ref={ref} geometry={edges}>
-      <lineBasicMaterial color="#ffffff" opacity={0.3} transparent />
+      <lineBasicMaterial color="#000000" opacity={0.2} transparent />
     </lineSegments>
   );
 }

--- a/src/components/three/FloatingShape.tsx
+++ b/src/components/three/FloatingShape.tsx
@@ -15,7 +15,7 @@ function OuterCube() {
   );
   return (
     <lineSegments ref={ref} geometry={edges}>
-      <lineBasicMaterial color="#000000" />
+      <lineBasicMaterial color="#ffffff" />
     </lineSegments>
   );
 }
@@ -33,7 +33,7 @@ function InnerCube() {
   );
   return (
     <lineSegments ref={ref} geometry={edges}>
-      <lineBasicMaterial color="#000000" opacity={0.2} transparent />
+      <lineBasicMaterial color="#ffffff" opacity={0.25} transparent />
     </lineSegments>
   );
 }
@@ -41,7 +41,7 @@ function InnerCube() {
 export default function FloatingShape() {
   return (
     <Canvas
-      camera={{ position: [0, 0, 5.5], fov: 38 }}
+      camera={{ position: [0, 0, 5], fov: 40 }}
       style={{ width: '100%', height: '100%', background: 'transparent' }}
       gl={{ alpha: true, antialias: true }}
     >

--- a/src/components/three/FloatingShape.tsx
+++ b/src/components/three/FloatingShape.tsx
@@ -1,0 +1,32 @@
+import { useRef } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import type { Mesh } from 'three';
+
+function Icosahedron() {
+  const ref = useRef<Mesh>(null);
+
+  useFrame(({ clock }) => {
+    if (!ref.current) return;
+    ref.current.rotation.x = clock.elapsedTime * 0.13;
+    ref.current.rotation.y = clock.elapsedTime * 0.20;
+  });
+
+  return (
+    <mesh ref={ref}>
+      <icosahedronGeometry args={[1.8, 1]} />
+      <meshBasicMaterial color="#111111" wireframe />
+    </mesh>
+  );
+}
+
+export default function FloatingShape() {
+  return (
+    <Canvas
+      camera={{ position: [0, 0, 5], fov: 40 }}
+      style={{ width: '100%', height: '100%', background: 'transparent' }}
+      gl={{ alpha: true, antialias: true }}
+    >
+      <Icosahedron />
+    </Canvas>
+  );
+}

--- a/src/components/three/FloatingShape.tsx
+++ b/src/components/three/FloatingShape.tsx
@@ -1,32 +1,58 @@
-import { useRef } from 'react';
+import { useRef, useMemo } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
-import type { Mesh } from 'three';
+import * as THREE from 'three';
 
-function Icosahedron() {
-  const ref = useRef<Mesh>(null);
+function OuterCube() {
+  const ref = useRef<THREE.LineSegments>(null);
 
   useFrame(({ clock }) => {
     if (!ref.current) return;
-    ref.current.rotation.x = clock.elapsedTime * 0.13;
-    ref.current.rotation.y = clock.elapsedTime * 0.20;
+    ref.current.rotation.x = clock.elapsedTime * 0.09;
+    ref.current.rotation.y = clock.elapsedTime * 0.14;
   });
 
+  const edges = useMemo(
+    () => new THREE.EdgesGeometry(new THREE.BoxGeometry(2.4, 2.4, 2.4)),
+    []
+  );
+
   return (
-    <mesh ref={ref}>
-      <icosahedronGeometry args={[1.8, 1]} />
-      <meshBasicMaterial color="#111111" wireframe />
-    </mesh>
+    <lineSegments ref={ref} geometry={edges}>
+      <lineBasicMaterial color="#ffffff" />
+    </lineSegments>
+  );
+}
+
+function InnerCube() {
+  const ref = useRef<THREE.LineSegments>(null);
+
+  useFrame(({ clock }) => {
+    if (!ref.current) return;
+    ref.current.rotation.x = -clock.elapsedTime * 0.06;
+    ref.current.rotation.y = -clock.elapsedTime * 0.10;
+  });
+
+  const edges = useMemo(
+    () => new THREE.EdgesGeometry(new THREE.BoxGeometry(1.3, 1.3, 1.3)),
+    []
+  );
+
+  return (
+    <lineSegments ref={ref} geometry={edges}>
+      <lineBasicMaterial color="#ffffff" opacity={0.3} transparent />
+    </lineSegments>
   );
 }
 
 export default function FloatingShape() {
   return (
     <Canvas
-      camera={{ position: [0, 0, 5], fov: 40 }}
+      camera={{ position: [0, 0, 5.5], fov: 38 }}
       style={{ width: '100%', height: '100%', background: 'transparent' }}
       gl={{ alpha: true, antialias: true }}
     >
-      <Icosahedron />
+      <OuterCube />
+      <InnerCube />
     </Canvas>
   );
 }

--- a/src/context/BookingContext.tsx
+++ b/src/context/BookingContext.tsx
@@ -1,6 +1,6 @@
-import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { buildCalendlyEmbedUrl } from "../lib/booking";
+import React, { createContext, useCallback, useContext } from "react";
+
+const CALENDLY_URL = "https://calendly.com/krglobalsolutionsltd/30-minute-meeting-clone";
 
 type BookingContextType = {
   isOpen: boolean;
@@ -16,103 +16,24 @@ export const useBooking = () => {
   return ctx;
 };
 
-function useLockBodyScroll(active: boolean) {
-  useEffect(() => {
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = active ? "hidden" : prev;
-    return () => { document.body.style.overflow = prev; };
-  }, [active]);
-}
-
-function useFocusTrap(active: boolean, containerRef: React.RefObject<HTMLDivElement>) {
-  useEffect(() => {
-    if (!active || !containerRef.current) return;
-    const container = containerRef.current;
-    const focusable = container.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
-    );
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Tab") {
-        if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault(); (last || first).focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault(); (first || last).focus();
-        }
-      }
-    };
-    document.addEventListener("keydown", handleKey);
-    (first || container).focus();
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [active, containerRef]);
-}
-
 export const BookingProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const [isOpen, setOpen] = useState(false);
-  const openBooking = useCallback(() => setOpen(true), []);
-  const closeBooking = useCallback(() => setOpen(false), []);
+  const openBooking = useCallback(() => {
+    const cal = (window as any).Calendly;
+    if (cal?.showPopupWidget) {
+      cal.showPopupWidget(CALENDLY_URL);
+    } else {
+      window.open(CALENDLY_URL, "_blank", "noopener,noreferrer");
+    }
+  }, []);
+
+  const closeBooking = useCallback(() => {
+    const cal = (window as any).Calendly;
+    if (cal?.closePopupWidget) cal.closePopupWidget();
+  }, []);
 
   return (
-    <BookingContext.Provider value={{ isOpen, openBooking, closeBooking }}>
+    <BookingContext.Provider value={{ isOpen: false, openBooking, closeBooking }}>
       {children}
-      <BookingModal />
     </BookingContext.Provider>
   );
 };
-
-const BookingModal: React.FC = () => {
-  const { t } = useTranslation();
-  const { isOpen, closeBooking } = useBooking();
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useLockBodyScroll(isOpen);
-  useFocusTrap(isOpen, containerRef);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeBooking();
-    };
-    if (isOpen) document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [isOpen, closeBooking]);
-
-  if (!isOpen) return null;
-
-  return (
-    <div
-      className="booking-backdrop"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="booking-title"
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) closeBooking();
-      }}
-    >
-      <div className="booking-modal" ref={containerRef} tabIndex={-1}>
-        <div className="booking-header">
-          <div id="booking-title" className="booking-title">
-            {t("booking.title")}
-          </div>
-          <button
-            type="button"
-            aria-label={t("booking.close")}
-            className="booking-close"
-            onClick={closeBooking}
-          >
-            ×
-          </button>
-        </div>
-        <div className="booking-content">
-          <iframe
-            className="booking-iframe"
-            title={t("booking.iframeTitle")}
-            src={buildCalendlyEmbedUrl()}
-            allow="payment *; microphone *; camera *; clipboard-read *; clipboard-write *;"
-          />
-        </div>
-      </div>
-    </div>
-  );
-};
-

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -3,7 +3,7 @@ export type QA = { q: string; a: string };
 export const faqFR: QA[] = [
   {
     q: "Qu'est-ce que KR Global Solutions LTD ?",
-    a: "KR Global Solutions LTD est une entreprise digitale basée à Londres (UK), fondée par Karim Hammouche et Raphaël Theuillon. Nous concevons des solutions digitales et des systèmes IA pour aider les entreprises à se transformer et à automatiser leurs opérations.",
+    a: "KR Global Solutions LTD est une entreprise digitale basée à Londres (UK). Nous concevons des solutions digitales et des systèmes IA pour aider les entreprises à se transformer et à automatiser leurs opérations.",
   },
   {
     q: "Quels sont vos projets actuels ?",
@@ -38,7 +38,7 @@ export const faqFR: QA[] = [
 export const faqEN: QA[] = [
   {
     q: "What is KR Global Solutions LTD?",
-    a: "KR Global Solutions LTD is a digital company based in London, UK, founded by Karim Hammouche and Raphaël Theuillon. We build digital solutions and AI systems to help businesses transform and automate their operations.",
+    a: "KR Global Solutions LTD is a digital company based in London, UK. We build digital solutions and AI systems to help businesses transform and automate their operations.",
   },
   {
     q: "What are your current projects?",

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -1,39 +1,71 @@
 export type QA = { q: string; a: string };
 
 export const faqFR: QA[] = [
-  { q: "Comment choisir le pack qui correspond le mieux à mes besoins ?", a: "Partez de votre objectif principal (visibilité rapide, croissance, clé en main). Le pack Découverte convient pour un démarrage rapide, Croissance pour un mini‑site + social + automatisations utiles, Sur‑mesure pour un projet complet (site 5–7 sections, boutique Stripe, IA avancée). Si besoin, nous pouvons ajuster le contenu de chaque pack." },
-  { q: "Les tarifs indiqués sont-ils fixes ou peuvent-ils varier ?", a: "Ce sont des tarifs “à partir de”. Ils sont ajustés selon la complexité de votre projet (scope, intégrations, délais). Un devis précis est fourni avant démarrage." },
-  { q: "Proposez-vous une mise en ligne ou une livraison express ?", a: "Oui, une option express est possible selon la charge et le périmètre. Indiquez votre deadline lors de la prise de contact." },
-  { q: "Puis-je payer en plusieurs fois ?", a: "Oui, des paiements échelonnés sont possibles sur certains packs (ex. 3×). Les modalités exactes sont confirmées dans le devis." },
-  { q: "Pouvez-vous personnaliser entièrement mon projet ?", a: "Oui. Le pack Sur‑mesure est prévu pour une personnalisation complète (branding, pages, intégrations, automatisations, IA)." },
-  { q: "Y a-t-il un accompagnement après la livraison ?", a: "Oui, un accompagnement d’un mois est inclus dans le pack Sur‑mesure. Pour les autres packs, des options de support peuvent être ajoutées." },
-  { q: "Puis-je demander des modifications après validation ?", a: "Oui, des révisions sont prévues pendant la phase de livraison. Après validation finale, un nouveau devis peut être établi si le scope change." },
-  { q: "Travaillez-vous avec des particuliers ou uniquement des entreprises ?", a: "Nous travaillons principalement avec des entreprises et des indépendants, mais des profils particuliers peuvent être étudiés." },
-  { q: "Créez-vous aussi le contenu (textes, visuels, vidéos) ?", a: "Oui, selon le pack. Découverte inclut un visuel simple ; Croissance inclut 15 posts + 1 micro‑vidéo ; Sur‑mesure inclut une gestion réseaux d’un mois. Des options supplémentaires sont possibles." },
-  { q: "Vos solutions sont-elles compatibles mobile et tablette ?", a: "Oui. Tous les livrables sont conçus en responsive (mobile, tablette, desktop)." },
-  { q: "Intervenez-vous à l’international ?", a: "Oui. Les prestations peuvent être réalisées à distance pour des clients internationaux." },
-  { q: "Proposez-vous des formations pour utiliser les outils livrés ?", a: "Oui. Une prise en main est incluse dans certains packs et peut être étendue (sessions, vidéos, documentation)." },
-  { q: "Avec quels outils/technologies travaillez-vous ?", a: "Principalement Next.js, React, TypeScript, Tailwind, Framer Motion, intégrations Stripe, Notion/Sheets, et agents IA (RAG)." },
-  { q: "Quelles sont les étapes typiques d’un projet ?", a: "Brief et devis → kick‑off → design/contenus → développement/intégrations → tests/SEO/accessibilité → mise en ligne → accompagnement." },
-  { q: "Quels délais prévoir pour un projet standard ?", a: "Selon le pack et votre disponibilité (contenus, validations). Découverte: rapide ; Croissance: court ; Sur‑mesure: variable. Une timeline est fournie au kick‑off." },
-  { q: "Puis-je migrer ou faire évoluer un projet existant ?", a: "Oui. Audit + plan d’action, puis migration ou refonte progressive selon vos priorités et contraintes." }
+  {
+    q: "Qu'est-ce que KR Global Solutions LTD ?",
+    a: "KR Global Solutions LTD est une entreprise digitale basée à Londres (UK), fondée par Karim Hammouche et Raphaël Theuillon. Nous concevons des solutions digitales et des systèmes IA pour aider les entreprises à se transformer et à automatiser leurs opérations.",
+  },
+  {
+    q: "Quels sont vos projets actuels ?",
+    a: "Nous travaillons activement sur deux projets : SiteEasy, une plateforme pour créer et commander un site web professionnel à 9,99€, et KR Global Agents, un système de 28 agents IA orchestrés pour automatiser la gestion d'une entreprise.",
+  },
+  {
+    q: "Qu'est-ce que SiteEasy ?",
+    a: "SiteEasy est une plateforme clé en main qui permet à n'importe quelle entreprise ou indépendant de commander un site web professionnel pour seulement 9,99€. Le tunnel de commande est entièrement automatisé : formulaire, paiement Stripe, confirmation email, livraison manuelle avec guide PDF.",
+  },
+  {
+    q: "Qu'est-ce que KR Global Agents ?",
+    a: "KR Global Agents est un système d'exploitation IA conçu pour piloter une entreprise. Il regroupe 28 agents spécialisés qui gèrent automatiquement les finances, les clients, le marketing, les réseaux sociaux, les prospects, la comptabilité et bien plus — tous connectés à une base Supabase centralisée.",
+  },
+  {
+    q: "Comment vous contacter ?",
+    a: "Vous pouvez nous écrire sur WhatsApp (+33 7 43 56 13 04), nous envoyer un email à contact@krglobalsolutionsltd.com, ou réserver un appel de 30 minutes via Calendly directement sur ce site.",
+  },
+  {
+    q: "Où êtes-vous basés ?",
+    a: "Notre siège social est à Londres, Royaume-Uni : 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ. Nous travaillons avec des clients en France, au Maroc et à l'international.",
+  },
+  {
+    q: "Proposez-vous des services sur mesure ?",
+    a: "Oui. Au-delà de nos produits SiteEasy et KR Global Agents, nous réalisons des projets sur mesure : sites web, automatisations, agents IA, stratégie digitale. Contactez-nous pour un devis.",
+  },
+  {
+    q: "Peut-on travailler avec vous à distance ?",
+    a: "Oui, nous opérons entièrement à distance. Tous nos livrables sont produits en remote pour des clients internationaux.",
+  },
 ];
 
 export const faqEN: QA[] = [
-  { q: "How do I choose the best pack for my needs?", a: "Start from your main goal (quick visibility, growth, turnkey). Starter is for fast launch, Growth for a mini‑site + social + useful automations, Custom for a complete project (5–7‑section site, Stripe shop, advanced AI). We can adjust each pack if needed." },
-  { q: "Are the listed prices fixed or can they vary?", a: "They are “from” prices. Final pricing depends on scope, integrations and deadlines. A precise quote is provided before kickoff." },
-  { q: "Do you offer express go‑live or expedited delivery?", a: "Yes, express delivery is possible depending on workload and scope. Share your deadline during contact." },
-  { q: "Can I pay in installments?", a: "Yes, staged payments (e.g., 3×) are available on some packs. Exact terms are confirmed in the quote." },
-  { q: "Can you fully customize my project?", a: "Yes. The Custom pack is designed for full customization (branding, pages, integrations, automations, AI)." },
-  { q: "Is there post‑delivery support?", a: "Yes, one month of guidance is included in the Custom pack. Other packs can add support options." },
-  { q: "Can I request changes after approval?", a: "Yes, revisions are planned during delivery. After final approval, scope changes may require a new quote." },
-  { q: "Do you work with individuals or only businesses?", a: "We mainly work with businesses and independents, but individual cases can be considered." },
-  { q: "Do you also create content (copy, visuals, videos)?", a: "Yes, depending on the pack. Starter includes a simple visual; Growth includes 15 posts + 1 micro‑video; Custom includes one‑month social management. Add‑ons are possible." },
-  { q: "Are your solutions mobile and tablet friendly?", a: "Yes. All deliverables are built responsive (mobile, tablet, desktop)." },
-  { q: "Do you work internationally?", a: "Yes. All services can be delivered remotely for international clients." },
-  { q: "Do you provide training to use the delivered tools?", a: "Yes. Onboarding is included in some packs and can be extended (sessions, videos, docs)." },
-  { q: "Which tools/technologies do you use?", a: "Mainly Next.js, React, TypeScript, Tailwind, Framer Motion, Stripe integrations, Notion/Sheets, and AI agents (RAG)." },
-  { q: "What are the typical project steps?", a: "Brief & quote → kickoff → design/content → development/integrations → tests/SEO/accessibility → go‑live → guidance." },
-  { q: "What timelines should I expect for a standard project?", a: "Depends on the pack and your availability (content, approvals). Starter: fast; Growth: short; Custom: variable. A timeline is provided at kickoff." },
-  { q: "Can you migrate or improve an existing project?", a: "Yes. We start with an audit + action plan, then migrate or progressively revamp based on priorities and constraints." }
+  {
+    q: "What is KR Global Solutions LTD?",
+    a: "KR Global Solutions LTD is a digital company based in London, UK, founded by Karim Hammouche and Raphaël Theuillon. We build digital solutions and AI systems to help businesses transform and automate their operations.",
+  },
+  {
+    q: "What are your current projects?",
+    a: "We are actively working on two projects: SiteEasy, a platform to order a professional website for €9.99, and KR Global Agents, a system of 28 orchestrated AI agents to automate business operations.",
+  },
+  {
+    q: "What is SiteEasy?",
+    a: "SiteEasy is a turnkey platform that lets any business or freelancer order a professional website for just €9.99. The order flow is fully automated: form, Stripe payment, email confirmation, manual delivery with a PDF guide.",
+  },
+  {
+    q: "What is KR Global Agents?",
+    a: "KR Global Agents is an AI operating system designed to run a business. It brings together 28 specialized agents that automatically handle finance, clients, marketing, social media, prospects, accounting, and more — all connected to a centralized Supabase database.",
+  },
+  {
+    q: "How can I contact you?",
+    a: "You can reach us on WhatsApp (+33 7 43 56 13 04), send an email to contact@krglobalsolutionsltd.com, or book a 30-minute call via Calendly directly on this site.",
+  },
+  {
+    q: "Where are you based?",
+    a: "Our registered office is in London, UK: 71–75 Shelton Street, Covent Garden, London, WC2H 9JQ. We work with clients in France, Morocco, and internationally.",
+  },
+  {
+    q: "Do you offer custom services?",
+    a: "Yes. Beyond our SiteEasy and KR Global Agents products, we deliver custom projects: websites, automations, AI agents, digital strategy. Contact us for a quote.",
+  },
+  {
+    q: "Can we work with you remotely?",
+    a: "Yes, we operate fully remotely. All deliverables are produced for international clients.",
+  },
 ];

--- a/src/data/translations.ts
+++ b/src/data/translations.ts
@@ -186,7 +186,7 @@ export const translations: Record<Language, Translation> = {
     footer: {
       legal: 'Mentions légales',
       copyright: '© KR Global LTD 2025',
-      legalNotice: 'KR GLOBAL SOLUTIONS LTD · Company No. 16517532 · 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ, UK · Private Limited Company\nDirectors: Karim Hammouche & Raphaël Theuillon · SIC: 46190 · 47910 · 62012 · 62090 · Email: karim@karimhammouche.com',
+      legalNotice: 'KR GLOBAL SOLUTIONS LTD · Company No. 16517532 · 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ, UK · Private Limited Company · SIC: 46190 · 47910 · 62012 · 62090 · Email: contact@krglobalsolutionsltd.com',
       social: {
         tiktok: 'TikTok',
         instagram: 'Instagram',
@@ -253,8 +253,8 @@ export const translations: Record<Language, Translation> = {
       },
     },
     portfolio: {
-      karim: 'Portfolio Karim',
-      raphael: 'Portfolio Raphaël',
+      karim: 'Portfolio K',
+      raphael: 'Portfolio R',
     },
   },
   en: {
@@ -312,7 +312,7 @@ export const translations: Record<Language, Translation> = {
     footer: {
       legal: 'Legal notice',
       copyright: '© KR Global LTD 2025',
-      legalNotice: 'KR GLOBAL SOLUTIONS LTD · Company No. 16517532 · 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ, UK · Private Limited Company\nDirectors: Karim Hammouche & Raphaël Theuillon · SIC: 46190 · 47910 · 62012 · 62090 · Email: karim@karimhammouche.com',
+      legalNotice: 'KR GLOBAL SOLUTIONS LTD · Company No. 16517532 · 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ, UK · Private Limited Company · SIC: 46190 · 47910 · 62012 · 62090 · Email: contact@krglobalsolutionsltd.com',
       social: {
         tiktok: 'TikTok',
         instagram: 'Instagram',
@@ -379,8 +379,8 @@ export const translations: Record<Language, Translation> = {
       },
     },
     portfolio: {
-      karim: "Karim's Portfolio",
-      raphael: "Raphaël's Portfolio",
+      karim: 'Portfolio K',
+      raphael: 'Portfolio R',
     },
   },
 };

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -1,19 +1,28 @@
 import { useState, useEffect } from 'react';
 import { Language, translations } from '../data/translations';
 
+const STORAGE_KEY = 'kr_lang';
+
+function getInitialLanguage(): Language {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'fr' || stored === 'en') return stored;
+  } catch {}
+  return 'fr';
+}
+
 export function useLanguage() {
-  const [currentLanguage, setCurrentLanguage] = useState<Language>('fr');
+  const [currentLanguage, setCurrentLanguage] = useState<Language>(getInitialLanguage);
 
   const t = translations[currentLanguage];
-  
-  const isRTL = false; // No RTL languages in the reduced set
+  const isRTL = false;
 
   useEffect(() => {
-    // Update document direction for RTL languages
-    document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
-  }, [isRTL]);
+    document.documentElement.dir = 'ltr';
+  }, []);
 
   const changeLanguage = (lang: Language) => {
+    try { localStorage.setItem(STORAGE_KEY, lang); } catch {}
     setCurrentLanguage(lang);
   };
 

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,8 @@ html {
 body {
   font-family: 'Inter', sans-serif;
   line-height: 1.6;
+  background: #000;
+  color: #f5f5f5;
 }
 
 /* SAFE-GUARD: fluid typography scales across devices */

--- a/src/index.css
+++ b/src/index.css
@@ -45,8 +45,8 @@ html {
 body {
   font-family: 'Inter', sans-serif;
   line-height: 1.6;
-  background: #fff;
-  color: #000;
+  background: #000;
+  color: #f0f0f0;
 }
 
 /* SAFE-GUARD: fluid typography scales across devices */

--- a/src/index.css
+++ b/src/index.css
@@ -45,8 +45,8 @@ html {
 body {
   font-family: 'Inter', sans-serif;
   line-height: 1.6;
-  background: #000;
-  color: #f0f0f0;
+  background: #fff;
+  color: #111;
 }
 
 /* SAFE-GUARD: fluid typography scales across devices */
@@ -61,6 +61,16 @@ body {
 .fs-base { font-size: var(--fs-base); }
 .fs-lg { font-size: var(--fs-lg); }
 .fs-xl { font-size: var(--fs-xl); }
+
+/* Marquee / infinite ticker */
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+.marquee-track {
+  animation: marquee linear var(--marquee-duration, 30s) infinite;
+  will-change: transform;
+}
 
 /* Custom animations */
 @keyframes orbital {

--- a/src/index.css
+++ b/src/index.css
@@ -45,8 +45,8 @@ html {
 body {
   font-family: 'Inter', sans-serif;
   line-height: 1.6;
-  background: #000;
-  color: #f5f5f5;
+  background: #fff;
+  color: #000;
 }
 
 /* SAFE-GUARD: fluid typography scales across devices */


### PR DESCRIPTION
## Corrections

- **FAQ** : noms des associés supprimés de la première réponse FR et EN
- **Section About** : bloc adresse (Siège social) supprimé
- **Projets** : pills tech, lien GitHub et icône lien externe supprimés — il reste uniquement "Voir le site →"
- **Calendly** : remplacement de l'iframe (bloquée par les headers CSP/X-Frame) par le widget popup officiel Calendly (`showPopupWidget`) — fallback `window.open` si le script n'est pas encore chargé

https://claude.ai/code/session_01VuffEHiMVXnfEYPsrCc7ko

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuffEHiMVXnfEYPsrCc7ko)_